### PR TITLE
Add comprehensive tests for gRPC sandbox implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5911,7 +5911,8 @@
         "@types/node": "^24.10.1",
         "ts-proto": "^2.6.1",
         "tsx": "^4.21.0",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.15"
       }
     }
   }

--- a/packages/sandbox-server/package.json
+++ b/packages/sandbox-server/package.json
@@ -16,6 +16,8 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsx watch src/server/index.ts",
     "start": "node dist/server/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "proto:generate": "buf generate",
     "proto:lint": "buf lint"
   },
@@ -31,6 +33,7 @@
     "@types/node": "^24.10.1",
     "ts-proto": "^2.6.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.15"
   }
 }

--- a/packages/sandbox-server/src/__tests__/cache-manager.test.ts
+++ b/packages/sandbox-server/src/__tests__/cache-manager.test.ts
@@ -1,0 +1,386 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { CacheManager, type CachedCode } from '../server/cache-manager.js';
+import { existsSync, mkdirSync, rmSync, readdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('CacheManager', () => {
+  const testCacheDir = '/tmp/prodisco-cache-test-' + Date.now();
+  let cacheManager: CacheManager;
+
+  beforeEach(() => {
+    // Clean up and create fresh test directory
+    if (existsSync(testCacheDir)) {
+      rmSync(testCacheDir, { recursive: true });
+    }
+    cacheManager = new CacheManager({ cacheDir: testCacheDir });
+  });
+
+  afterEach(() => {
+    // Clean up test directory
+    if (existsSync(testCacheDir)) {
+      rmSync(testCacheDir, { recursive: true });
+    }
+  });
+
+  describe('Constructor', () => {
+    it('creates cache directory if it does not exist', () => {
+      const customDir = testCacheDir + '-custom';
+      try {
+        expect(existsSync(customDir)).toBe(false);
+        new CacheManager({ cacheDir: customDir });
+        expect(existsSync(customDir)).toBe(true);
+      } finally {
+        if (existsSync(customDir)) {
+          rmSync(customDir, { recursive: true });
+        }
+      }
+    });
+
+    it('uses SCRIPTS_CACHE_DIR from environment if not configured', () => {
+      const originalEnv = process.env.SCRIPTS_CACHE_DIR;
+      const envDir = testCacheDir + '-env';
+
+      try {
+        process.env.SCRIPTS_CACHE_DIR = envDir;
+        const manager = new CacheManager();
+        expect(existsSync(envDir)).toBe(true);
+      } finally {
+        process.env.SCRIPTS_CACHE_DIR = originalEnv;
+        if (existsSync(envDir)) {
+          rmSync(envDir, { recursive: true });
+        }
+      }
+    });
+
+    it('uses default /tmp/prodisco-scripts if no config or env', () => {
+      const originalEnv = process.env.SCRIPTS_CACHE_DIR;
+      try {
+        delete process.env.SCRIPTS_CACHE_DIR;
+        const manager = new CacheManager();
+        // Just verify it doesn't throw
+        expect(manager).toBeInstanceOf(CacheManager);
+      } finally {
+        if (originalEnv) {
+          process.env.SCRIPTS_CACHE_DIR = originalEnv;
+        }
+      }
+    });
+  });
+
+  describe('cache()', () => {
+    it('caches code and returns filename', async () => {
+      const code = 'console.log("test");';
+      const filename = await cacheManager.cache(code);
+
+      expect(filename).toBeDefined();
+      expect(filename).toMatch(/^script-.*\.ts$/);
+    });
+
+    it('creates file with correct content', async () => {
+      const code = 'console.log("hello world");';
+      const filename = await cacheManager.cache(code);
+
+      expect(filename).toBeDefined();
+      const filePath = join(testCacheDir, filename!);
+      expect(existsSync(filePath)).toBe(true);
+
+      const content = readFileSync(filePath, 'utf-8');
+      expect(content).toContain('// Executed via sandbox at');
+      expect(content).toContain(code);
+    });
+
+    it('uses hash-based filename for deduplication', async () => {
+      const code = 'console.log("unique code");';
+
+      const filename1 = await cacheManager.cache(code);
+      const filename2 = await cacheManager.cache(code);
+
+      // Second cache should return undefined (already cached)
+      expect(filename1).toBeDefined();
+      expect(filename2).toBeUndefined();
+    });
+
+    it('caches different code separately', async () => {
+      const code1 = 'console.log("code 1");';
+      const code2 = 'console.log("code 2");';
+
+      const filename1 = await cacheManager.cache(code1);
+      const filename2 = await cacheManager.cache(code2);
+
+      expect(filename1).toBeDefined();
+      expect(filename2).toBeDefined();
+      expect(filename1).not.toBe(filename2);
+    });
+
+    it('includes timestamp in filename', async () => {
+      const code = 'console.log("timestamp test");';
+      const filename = await cacheManager.cache(code);
+
+      expect(filename).toBeDefined();
+      // Format: script-YYYY-MM-DDTHH-MM-SS-hash.ts
+      expect(filename).toMatch(/^script-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-[a-f0-9]{12}\.ts$/);
+    });
+
+    it('includes hash in filename', async () => {
+      const code = 'console.log("hash test");';
+      const filename = await cacheManager.cache(code);
+
+      expect(filename).toBeDefined();
+      // Should contain a 12-character hex hash
+      expect(filename).toMatch(/-[a-f0-9]{12}\.ts$/);
+    });
+
+    it('handles concurrent cache calls safely', async () => {
+      const codes = Array.from({ length: 10 }, (_, i) => `console.log("${i}");`);
+
+      const results = await Promise.all(codes.map(code => cacheManager.cache(code)));
+
+      // All unique codes should be cached
+      const filenames = results.filter(r => r !== undefined);
+      expect(filenames.length).toBe(10);
+      expect(new Set(filenames).size).toBe(10);
+    });
+
+    it('returns undefined on caching error (silently fails)', async () => {
+      // Create a manager with a valid directory first
+      const validDir = testCacheDir + '-silent-fail';
+      const manager = new CacheManager({ cacheDir: validDir });
+
+      // Delete the directory to simulate a write failure scenario
+      if (existsSync(validDir)) {
+        rmSync(validDir, { recursive: true });
+      }
+
+      // The cache method should recreate the directory and succeed
+      // This test verifies the cache method doesn't throw on retries
+      const result = await manager.cache('console.log("test");');
+      // Since the directory gets recreated, it should actually succeed
+      expect(result).toBeDefined();
+
+      // Clean up
+      if (existsSync(validDir)) {
+        rmSync(validDir, { recursive: true });
+      }
+    });
+  });
+
+  describe('find()', () => {
+    beforeEach(async () => {
+      // Pre-populate with some test scripts
+      const scripts = [
+        { name: 'script-2024-01-01T00-00-00-abc123def456.ts', content: 'console.log("first");' },
+        { name: 'script-2024-01-02T00-00-00-bcd234efg567.ts', content: 'console.log("second");' },
+        { name: 'list-pods.ts', content: '// List all pods\nconsole.log("pods");' },
+      ];
+
+      for (const script of scripts) {
+        writeFileSync(join(testCacheDir, script.name), script.content);
+      }
+    });
+
+    it('finds script by exact filename', () => {
+      const result = cacheManager.find('list-pods.ts');
+
+      expect(result).not.toBeNull();
+      expect(result!.filename).toBe('list-pods.ts');
+      expect(result!.path).toBe(join(testCacheDir, 'list-pods.ts'));
+    });
+
+    it('finds script by filename without .ts extension', () => {
+      const result = cacheManager.find('list-pods');
+
+      expect(result).not.toBeNull();
+      expect(result!.filename).toBe('list-pods.ts');
+    });
+
+    it('finds script by partial match', () => {
+      const result = cacheManager.find('pods');
+
+      expect(result).not.toBeNull();
+      expect(result!.filename).toBe('list-pods.ts');
+    });
+
+    it('finds script by hash partial match', () => {
+      const result = cacheManager.find('abc123');
+
+      expect(result).not.toBeNull();
+      expect(result!.filename).toContain('abc123');
+    });
+
+    it('case-insensitive partial match', () => {
+      const result = cacheManager.find('PODS');
+
+      expect(result).not.toBeNull();
+      expect(result!.filename).toBe('list-pods.ts');
+    });
+
+    it('returns null for non-existent script', () => {
+      const result = cacheManager.find('non-existent-script');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when cache directory does not exist', () => {
+      const manager = new CacheManager({ cacheDir: '/tmp/non-existent-dir-' + Date.now() });
+      const result = manager.find('any-script');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns correct CachedCode structure', () => {
+      const result = cacheManager.find('list-pods');
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveProperty('path');
+      expect(result).toHaveProperty('filename');
+      expect(result).toHaveProperty('code');
+      expect(typeof result!.path).toBe('string');
+      expect(typeof result!.filename).toBe('string');
+      expect(typeof result!.code).toBe('string');
+    });
+
+    it('returns code content in result', () => {
+      const result = cacheManager.find('list-pods');
+
+      expect(result).not.toBeNull();
+      expect(result!.code).toContain('console.log("pods")');
+    });
+
+    it('strips header comment from code', () => {
+      // Add a script with the standard header
+      const headerContent = '// Executed via sandbox at 2024-01-01T00:00:00.000Z\nconsole.log("test");';
+      writeFileSync(join(testCacheDir, 'with-header.ts'), headerContent);
+
+      const result = cacheManager.find('with-header');
+
+      expect(result).not.toBeNull();
+      expect(result!.code).toBe('console.log("test");');
+      expect(result!.code).not.toContain('// Executed via');
+    });
+
+    it('preserves code without header', () => {
+      const result = cacheManager.find('list-pods');
+
+      expect(result).not.toBeNull();
+      // The list-pods script has a different comment format, so it should be preserved
+      expect(result!.code).toContain('// List all pods');
+    });
+
+    it('prefers exact match over partial match', () => {
+      // Add scripts that could cause partial match ambiguity
+      writeFileSync(join(testCacheDir, 'test.ts'), 'console.log("test");');
+      writeFileSync(join(testCacheDir, 'test-extended.ts'), 'console.log("test-extended");');
+
+      const result = cacheManager.find('test.ts');
+
+      expect(result).not.toBeNull();
+      expect(result!.filename).toBe('test.ts');
+    });
+
+    it('only returns .ts files', () => {
+      // Add a non-ts file
+      writeFileSync(join(testCacheDir, 'readme.md'), '# Readme');
+
+      const result = cacheManager.find('readme');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('Mutex Behavior', () => {
+    it('serializes concurrent cache operations', async () => {
+      const operations: number[] = [];
+
+      // Create cache operations that log their order
+      const promises = Array.from({ length: 5 }, (_, i) =>
+        cacheManager.cache(`console.log("operation ${i}");`).then(() => {
+          operations.push(i);
+        })
+      );
+
+      await Promise.all(promises);
+
+      // All operations should complete
+      expect(operations.length).toBe(5);
+      // Each operation should be unique
+      expect(new Set(operations).size).toBe(5);
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('handles empty code', async () => {
+      const filename = await cacheManager.cache('');
+
+      expect(filename).toBeDefined();
+      const filePath = join(testCacheDir, filename!);
+      const content = readFileSync(filePath, 'utf-8');
+      // Should have just the header
+      expect(content).toContain('// Executed via sandbox at');
+    });
+
+    it('handles code with special characters', async () => {
+      const code = 'console.log("Special: $`\\n\\t{}[]");';
+      const filename = await cacheManager.cache(code);
+
+      expect(filename).toBeDefined();
+      const result = cacheManager.find(filename!);
+      expect(result!.code).toContain(code);
+    });
+
+    it('handles code with Unicode', async () => {
+      const code = 'console.log("Hello 世界 🌍");';
+      const filename = await cacheManager.cache(code);
+
+      expect(filename).toBeDefined();
+      const result = cacheManager.find(filename!);
+      expect(result!.code).toContain('世界');
+      expect(result!.code).toContain('🌍');
+    });
+
+    it('handles very long code', async () => {
+      const code = 'console.log("a".repeat(10000));';
+      const filename = await cacheManager.cache(code);
+
+      expect(filename).toBeDefined();
+    });
+
+    it('recreates cache directory if deleted between operations', async () => {
+      // Cache something first
+      await cacheManager.cache('console.log("first");');
+
+      // Delete the cache directory
+      rmSync(testCacheDir, { recursive: true });
+
+      // Cache again - should recreate directory
+      const filename = await cacheManager.cache('console.log("second");');
+
+      expect(filename).toBeDefined();
+      expect(existsSync(testCacheDir)).toBe(true);
+    });
+  });
+
+  describe('File Listing', () => {
+    it('lists multiple cached scripts', async () => {
+      const codes = [
+        'console.log("first");',
+        'console.log("second");',
+        'console.log("third");',
+      ];
+
+      for (const code of codes) {
+        await cacheManager.cache(code);
+      }
+
+      const files = readdirSync(testCacheDir).filter(f => f.endsWith('.ts'));
+      expect(files.length).toBe(3);
+    });
+
+    it('all cached files have .ts extension', async () => {
+      await cacheManager.cache('console.log("test");');
+
+      const files = readdirSync(testCacheDir);
+      const tsFiles = files.filter(f => f.endsWith('.ts'));
+      expect(tsFiles.length).toBe(files.length);
+    });
+  });
+});

--- a/packages/sandbox-server/src/__tests__/executor.test.ts
+++ b/packages/sandbox-server/src/__tests__/executor.test.ts
@@ -1,0 +1,569 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { Executor, type ExecutionResult, type ExecutorConfig } from '../server/executor.js';
+
+describe('Executor', () => {
+  let executor: Executor;
+
+  beforeEach(() => {
+    executor = new Executor();
+  });
+
+  describe('Basic Execution', () => {
+    it('executes simple console.log', async () => {
+      const result = await executor.execute('console.log("hello world")');
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('hello world');
+      expect(result.error).toBeUndefined();
+      expect(result.executionTimeMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('executes multiple console.log statements', async () => {
+      const result = await executor.execute(`
+        console.log("line 1");
+        console.log("line 2");
+        console.log("line 3");
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('line 1\nline 2\nline 3');
+    });
+
+    it('handles console.error', async () => {
+      const result = await executor.execute('console.error("error message")');
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('[ERROR] error message');
+    });
+
+    it('handles console.warn', async () => {
+      const result = await executor.execute('console.warn("warning message")');
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('[WARN] warning message');
+    });
+
+    it('handles console.info', async () => {
+      const result = await executor.execute('console.info("info message")');
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('[INFO] info message');
+    });
+
+    it('handles mixed console output', async () => {
+      const result = await executor.execute(`
+        console.log("log");
+        console.error("error");
+        console.warn("warn");
+        console.info("info");
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('log\n[ERROR] error\n[WARN] warn\n[INFO] info');
+    });
+  });
+
+  describe('TypeScript Support', () => {
+    it('executes TypeScript code with type annotations', async () => {
+      const result = await executor.execute(`
+        const x: number = 42;
+        const y: string = "hello";
+        console.log(x, y);
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('42 hello');
+    });
+
+    it('executes TypeScript interfaces', async () => {
+      const result = await executor.execute(`
+        interface Person {
+          name: string;
+          age: number;
+        }
+        const person: Person = { name: "Alice", age: 30 };
+        console.log(person.name, person.age);
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('Alice 30');
+    });
+
+    it('executes TypeScript generics', async () => {
+      const result = await executor.execute(`
+        function identity<T>(arg: T): T {
+          return arg;
+        }
+        console.log(identity<string>("test"));
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('test');
+    });
+
+    it('executes TypeScript enums', async () => {
+      const result = await executor.execute(`
+        enum Color { Red = 1, Green = 2, Blue = 3 }
+        console.log(Color.Green);
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('2');
+    });
+  });
+
+  describe('Async/Await Support', () => {
+    it('executes async code with await', async () => {
+      const result = await executor.execute(`
+        const delay = (ms: number) => new Promise(r => setTimeout(r, ms));
+        await delay(10);
+        console.log("done");
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('done');
+    });
+
+    it('executes multiple awaits', async () => {
+      const result = await executor.execute(`
+        const delay = (ms: number) => new Promise(r => setTimeout(r, ms));
+        console.log("start");
+        await delay(5);
+        console.log("middle");
+        await delay(5);
+        console.log("end");
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('start\nmiddle\nend');
+    });
+
+    it('handles Promise.all', async () => {
+      const result = await executor.execute(`
+        const results = await Promise.all([
+          Promise.resolve(1),
+          Promise.resolve(2),
+          Promise.resolve(3)
+        ]);
+        console.log(results.join(","));
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('1,2,3');
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('catches thrown errors', async () => {
+      const result = await executor.execute('throw new Error("test error")');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('test error');
+    });
+
+    it('catches type errors', async () => {
+      const result = await executor.execute(`
+        const x: any = null;
+        x.foo.bar;
+      `);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Cannot read properties of null");
+    });
+
+    it('catches syntax errors during transform', async () => {
+      const result = await executor.execute('const x = {');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('catches reference errors', async () => {
+      const result = await executor.execute('console.log(undefinedVariable)');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('undefinedVariable');
+    });
+
+    it('catches async rejection errors', async () => {
+      const result = await executor.execute(`
+        await Promise.reject(new Error("async error"));
+      `);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('async error');
+    });
+
+    it('preserves output before error', async () => {
+      const result = await executor.execute(`
+        console.log("before error");
+        throw new Error("test error");
+      `);
+
+      expect(result.success).toBe(false);
+      expect(result.output).toBe('before error');
+      expect(result.error).toBe('test error');
+    });
+  });
+
+  describe('Timeout Handling', () => {
+    it('times out long-running code', async () => {
+      const result = await executor.execute(`
+        await new Promise(r => setTimeout(r, 5000));
+      `, 100);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Script execution timed out');
+    });
+
+    it('clamps timeout to minimum 1000ms', async () => {
+      const startTime = Date.now();
+      const result = await executor.execute(`
+        console.log("quick");
+      `, 1);
+
+      // Even with timeout=1, it should execute (clamped to 1000ms minimum)
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('quick');
+    });
+
+    it('clamps timeout to maximum 120000ms', async () => {
+      // Just verify it doesn't throw with a large timeout
+      const result = await executor.execute('console.log("test")', 999999);
+      expect(result.success).toBe(true);
+    });
+
+    it('uses default 30000ms timeout', async () => {
+      const result = await executor.execute('console.log("test")');
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('Sandbox Context - Built-in Objects', () => {
+    it('provides JSON object', async () => {
+      const result = await executor.execute(`
+        const obj = { a: 1, b: 2 };
+        console.log(JSON.stringify(obj));
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('{"a":1,"b":2}');
+    });
+
+    it('provides Math object', async () => {
+      const result = await executor.execute(`
+        console.log(Math.max(1, 2, 3));
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('3');
+    });
+
+    it('provides Date object', async () => {
+      const result = await executor.execute(`
+        const d = new Date(2024, 0, 1);
+        console.log(d.getFullYear());
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('2024');
+    });
+
+    it('provides Array methods', async () => {
+      const result = await executor.execute(`
+        const arr = [1, 2, 3];
+        console.log(arr.map(x => x * 2).join(","));
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('2,4,6');
+    });
+
+    it('provides Object methods', async () => {
+      const result = await executor.execute(`
+        const obj = { a: 1, b: 2 };
+        console.log(Object.keys(obj).join(","));
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('a,b');
+    });
+
+    it('provides Buffer object', async () => {
+      const result = await executor.execute(`
+        const buf = Buffer.from("hello");
+        console.log(buf.toString("base64"));
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('aGVsbG8=');
+    });
+
+    it('provides Promise', async () => {
+      const result = await executor.execute(`
+        const p = new Promise(resolve => resolve(42));
+        const value = await p;
+        console.log(value);
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('42');
+    });
+  });
+
+  describe('Sandbox Context - Timers', () => {
+    it('provides setTimeout', async () => {
+      const result = await executor.execute(`
+        await new Promise(r => setTimeout(() => {
+          console.log("delayed");
+          r(undefined);
+        }, 10));
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('delayed');
+    });
+
+    it('provides clearTimeout', async () => {
+      const result = await executor.execute(`
+        const id = setTimeout(() => console.log("should not run"), 1000);
+        clearTimeout(id);
+        console.log("cleared");
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('cleared');
+    });
+
+    it('provides setInterval and clearInterval', async () => {
+      const result = await executor.execute(`
+        let count = 0;
+        const id = setInterval(() => {
+          count++;
+          if (count >= 3) {
+            clearInterval(id);
+          }
+        }, 10);
+        await new Promise(r => setTimeout(r, 100));
+        console.log(count);
+      `);
+
+      expect(result.success).toBe(true);
+      expect(parseInt(result.output)).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe('Sandbox Context - Require', () => {
+    it('allows require of @kubernetes/client-node', async () => {
+      const result = await executor.execute(`
+        const k8s = require('@kubernetes/client-node');
+        console.log(typeof k8s.KubeConfig);
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('function');
+    });
+
+    it('allows require of prometheus-query', async () => {
+      const result = await executor.execute(`
+        const prom = require('prometheus-query');
+        console.log(typeof prom.PrometheusDriver);
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('function');
+    });
+
+    it('blocks require of unauthorized modules', async () => {
+      const result = await executor.execute(`
+        const fs = require('fs');
+      `);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Module 'fs' not available in sandbox");
+    });
+
+    it('blocks require of child_process', async () => {
+      const result = await executor.execute(`
+        const cp = require('child_process');
+      `);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Module 'child_process' not available in sandbox");
+    });
+  });
+
+  describe('Sandbox Context - Kubernetes', () => {
+    it('provides pre-configured KubeConfig (kc)', async () => {
+      const result = await executor.execute(`
+        console.log(typeof kc);
+        console.log(typeof kc.getCurrentContext);
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('object\nfunction');
+    });
+
+    it('provides k8s library', async () => {
+      const result = await executor.execute(`
+        console.log(typeof k8s);
+        console.log(typeof k8s.KubeConfig);
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('object\nfunction');
+    });
+
+    it('can create API clients from kc', async () => {
+      const result = await executor.execute(`
+        const api = kc.makeApiClient(k8s.CoreV1Api);
+        console.log(typeof api);
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('object');
+    });
+  });
+
+  describe('Sandbox Context - Environment', () => {
+    it('provides access to process.env', async () => {
+      const result = await executor.execute(`
+        console.log(typeof process.env);
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('object');
+    });
+
+    it('can read environment variables', async () => {
+      const result = await executor.execute(`
+        // PATH should always be defined
+        console.log(typeof process.env.PATH);
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('string');
+    });
+  });
+
+  describe('Kubernetes Context', () => {
+    it('returns current kubernetes context name', () => {
+      const context = executor.getKubernetesContext();
+      expect(typeof context).toBe('string');
+      // Context should be either a valid name or 'unknown'
+      expect(context.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Executor Configuration', () => {
+    it('accepts prometheus URL in config', () => {
+      const configuredExecutor = new Executor({
+        prometheusUrl: 'http://localhost:9090'
+      });
+      expect(configuredExecutor).toBeInstanceOf(Executor);
+    });
+
+    it('uses PROMETHEUS_URL from environment', () => {
+      const originalUrl = process.env.PROMETHEUS_URL;
+      process.env.PROMETHEUS_URL = 'http://test:9090';
+
+      const configuredExecutor = new Executor();
+      expect(configuredExecutor).toBeInstanceOf(Executor);
+
+      // Restore
+      if (originalUrl) {
+        process.env.PROMETHEUS_URL = originalUrl;
+      } else {
+        delete process.env.PROMETHEUS_URL;
+      }
+    });
+  });
+
+  describe('Execution Result Structure', () => {
+    it('returns correct result structure on success', async () => {
+      const result = await executor.execute('console.log("test")');
+
+      expect(result).toHaveProperty('success');
+      expect(result).toHaveProperty('output');
+      expect(result).toHaveProperty('executionTimeMs');
+      expect(typeof result.success).toBe('boolean');
+      expect(typeof result.output).toBe('string');
+      expect(typeof result.executionTimeMs).toBe('number');
+    });
+
+    it('returns correct result structure on failure', async () => {
+      const result = await executor.execute('throw new Error("test")');
+
+      expect(result).toHaveProperty('success');
+      expect(result).toHaveProperty('output');
+      expect(result).toHaveProperty('error');
+      expect(result).toHaveProperty('executionTimeMs');
+      expect(typeof result.success).toBe('boolean');
+      expect(typeof result.output).toBe('string');
+      expect(typeof result.error).toBe('string');
+      expect(typeof result.executionTimeMs).toBe('number');
+    });
+
+    it('tracks execution time', async () => {
+      const result = await executor.execute(`
+        await new Promise(r => setTimeout(r, 50));
+        console.log("done");
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.executionTimeMs).toBeGreaterThanOrEqual(40);
+      expect(result.executionTimeMs).toBeLessThan(5000);
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('handles empty code', async () => {
+      const result = await executor.execute('');
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('');
+    });
+
+    it('handles code with only whitespace', async () => {
+      const result = await executor.execute('   \n\t  ');
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('');
+    });
+
+    it('handles code with only comments', async () => {
+      const result = await executor.execute('// just a comment');
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('');
+    });
+
+    it('handles Unicode output', async () => {
+      const result = await executor.execute('console.log("Hello 世界 🌍")');
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('Hello 世界 🌍');
+    });
+
+    it('handles large output', async () => {
+      const result = await executor.execute(`
+        for (let i = 0; i < 100; i++) {
+          console.log("line " + i);
+        }
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output.split('\n').length).toBe(100);
+    });
+
+    it('handles complex nested objects in console.log', async () => {
+      const result = await executor.execute(`
+        const obj = { a: { b: { c: 1 } } };
+        console.log(JSON.stringify(obj));
+      `);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('{"a":{"b":{"c":1}}}');
+    });
+  });
+});

--- a/packages/sandbox-server/src/__tests__/integration.test.ts
+++ b/packages/sandbox-server/src/__tests__/integration.test.ts
@@ -1,0 +1,470 @@
+import { describe, expect, it, beforeAll, afterAll, beforeEach } from 'vitest';
+import * as grpc from '@grpc/grpc-js';
+import { existsSync, rmSync, unlinkSync } from 'node:fs';
+import { startServer } from '../server/index.js';
+import { SandboxClient } from '../client/index.js';
+
+describe('Integration Tests - Client/Server Communication', () => {
+  const testSocketPath = `/tmp/prodisco-sandbox-test-${Date.now()}.sock`;
+  const testCacheDir = `/tmp/prodisco-cache-integration-${Date.now()}`;
+  let server: grpc.Server;
+  let client: SandboxClient;
+
+  beforeAll(async () => {
+    // Start the server
+    server = await startServer({
+      socketPath: testSocketPath,
+      cacheDir: testCacheDir,
+    });
+
+    // Create client
+    client = new SandboxClient({ socketPath: testSocketPath });
+
+    // Wait for server to be healthy
+    const healthy = await client.waitForHealthy(5000);
+    expect(healthy).toBe(true);
+  });
+
+  afterAll(async () => {
+    // Close client
+    client.close();
+
+    // Shutdown server
+    await new Promise<void>((resolve) => {
+      server.tryShutdown((err) => {
+        if (err) {
+          server.forceShutdown();
+        }
+        resolve();
+      });
+    });
+
+    // Clean up socket file
+    if (existsSync(testSocketPath)) {
+      try {
+        unlinkSync(testSocketPath);
+      } catch {
+        // Ignore
+      }
+    }
+
+    // Clean up cache directory
+    if (existsSync(testCacheDir)) {
+      rmSync(testCacheDir, { recursive: true });
+    }
+  });
+
+  describe('Health Check', () => {
+    it('returns healthy status', async () => {
+      const result = await client.healthCheck();
+
+      expect(result.healthy).toBe(true);
+    });
+
+    it('returns kubernetes context', async () => {
+      const result = await client.healthCheck();
+
+      expect(result.kubernetesContext).toBeDefined();
+      expect(typeof result.kubernetesContext).toBe('string');
+    });
+  });
+
+  describe('Code Execution', () => {
+    it('executes simple code', async () => {
+      const result = await client.execute({
+        code: 'console.log("hello from integration test")',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('hello from integration test');
+      expect(result.error).toBeUndefined();
+    });
+
+    it('handles multiple console outputs', async () => {
+      const result = await client.execute({
+        code: `
+          console.log("line 1");
+          console.log("line 2");
+          console.log("line 3");
+        `,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('line 1\nline 2\nline 3');
+    });
+
+    it('handles async code', async () => {
+      const result = await client.execute({
+        code: `
+          await new Promise(r => setTimeout(r, 10));
+          console.log("async complete");
+        `,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('async complete');
+    });
+
+    it('handles TypeScript code', async () => {
+      const result = await client.execute({
+        code: `
+          interface User { name: string; }
+          const user: User = { name: "Test" };
+          console.log(user.name);
+        `,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('Test');
+    });
+
+    it('handles execution errors', async () => {
+      const result = await client.execute({
+        code: 'throw new Error("intentional error")',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('intentional error');
+    });
+
+    it('respects timeout', async () => {
+      const result = await client.execute({
+        code: 'await new Promise(r => setTimeout(r, 10000))',
+        timeoutMs: 100,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Script execution timed out');
+    });
+
+    it('returns execution time', async () => {
+      const result = await client.execute({
+        code: 'console.log("timing test")',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.executionTimeMs).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('Caching', () => {
+    it('caches successful executions', async () => {
+      const code = `console.log("cache integration test ${Date.now()}")`;
+      const result = await client.execute({ code });
+
+      expect(result.success).toBe(true);
+      expect(result.cachedAs).toBeDefined();
+      expect(result.cachedAs).toMatch(/^script-.*\.ts$/);
+    });
+
+    it('can execute cached scripts', async () => {
+      const uniqueValue = `unique-${Date.now()}`;
+      const code = `console.log("${uniqueValue}")`;
+
+      // First execution - gets cached
+      const firstResult = await client.execute({ code });
+      expect(firstResult.success).toBe(true);
+      expect(firstResult.cachedAs).toBeDefined();
+
+      // Execute from cache
+      const cachedResult = await client.execute({
+        cached: firstResult.cachedAs!,
+      });
+
+      expect(cachedResult.success).toBe(true);
+      expect(cachedResult.output).toBe(uniqueValue);
+      expect(cachedResult.cachedAs).toBe(firstResult.cachedAs);
+    });
+
+    it('returns error for non-existent cached script', async () => {
+      const result = await client.execute({
+        cached: 'non-existent-script-12345',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not found');
+    });
+
+    it('deduplicates cache for identical code', async () => {
+      const code = `console.log("dedupe test ${Date.now()}")`;
+
+      const result1 = await client.execute({ code });
+      const result2 = await client.execute({ code });
+
+      expect(result1.success).toBe(true);
+      expect(result2.success).toBe(true);
+      expect(result1.cachedAs).toBeDefined();
+      // Second execution of same code should not create new cache entry
+      expect(result2.cachedAs).toBeUndefined();
+    });
+  });
+
+  describe('Kubernetes Context', () => {
+    it('provides k8s library in sandbox', async () => {
+      const result = await client.execute({
+        code: 'console.log(typeof k8s.KubeConfig)',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('function');
+    });
+
+    it('provides pre-configured KubeConfig', async () => {
+      const result = await client.execute({
+        code: 'console.log(typeof kc.getCurrentContext)',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('function');
+    });
+
+    it('can create API clients', async () => {
+      const result = await client.execute({
+        code: `
+          const api = kc.makeApiClient(k8s.CoreV1Api);
+          console.log(typeof api);
+        `,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('object');
+    });
+  });
+
+  describe('Require Support', () => {
+    it('allows require of @kubernetes/client-node', async () => {
+      const result = await client.execute({
+        code: `
+          const k8s = require('@kubernetes/client-node');
+          console.log(typeof k8s.KubeConfig);
+        `,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('function');
+    });
+
+    it('allows require of prometheus-query', async () => {
+      const result = await client.execute({
+        code: `
+          const prom = require('prometheus-query');
+          console.log(typeof prom.PrometheusDriver);
+        `,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('function');
+    });
+
+    it('blocks require of fs', async () => {
+      const result = await client.execute({
+        code: 'const fs = require("fs")',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Module 'fs' not available");
+    });
+  });
+
+  describe('Concurrent Requests', () => {
+    it('handles multiple concurrent executions', async () => {
+      const requests = Array.from({ length: 10 }, (_, i) => ({
+        code: `console.log("concurrent ${i}")`,
+      }));
+
+      const results = await Promise.all(
+        requests.map(req => client.execute(req))
+      );
+
+      expect(results.every(r => r.success)).toBe(true);
+      results.forEach((result, i) => {
+        expect(result.output).toBe(`concurrent ${i}`);
+      });
+    });
+
+    it('handles mixed success/failure concurrent requests', async () => {
+      const requests = [
+        { code: 'console.log("success")' },
+        { code: 'throw new Error("fail")' },
+        { code: 'console.log("success 2")' },
+      ];
+
+      const results = await Promise.all(
+        requests.map(req => client.execute(req))
+      );
+
+      expect(results[0].success).toBe(true);
+      expect(results[1].success).toBe(false);
+      expect(results[2].success).toBe(true);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('handles syntax errors', async () => {
+      const result = await client.execute({
+        code: 'const x = {',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('handles runtime errors', async () => {
+      const result = await client.execute({
+        code: 'undefinedVariable.property',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('undefinedVariable');
+    });
+
+    it('handles async rejection', async () => {
+      const result = await client.execute({
+        code: 'await Promise.reject(new Error("async fail"))',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('async fail');
+    });
+
+    it('preserves output before error', async () => {
+      const result = await client.execute({
+        code: `
+          console.log("before");
+          throw new Error("after");
+        `,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.output).toBe('before');
+      expect(result.error).toBe('after');
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('handles empty code (treated as no source by client)', async () => {
+      // Note: The client treats empty string as falsy, so source is undefined
+      // This results in "Either code or cached must be provided" error
+      const result = await client.execute({ code: '' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Either code or cached must be provided');
+    });
+
+    it('handles code with only whitespace', async () => {
+      // Whitespace is truthy, so this gets executed
+      const result = await client.execute({ code: '   ' });
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('');
+    });
+
+    it('handles code with Unicode', async () => {
+      const result = await client.execute({
+        code: 'console.log("Hello 世界 🌍")',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('Hello 世界 🌍');
+    });
+
+    it('handles large output', async () => {
+      const result = await client.execute({
+        code: `
+          for (let i = 0; i < 100; i++) {
+            console.log("line " + i);
+          }
+        `,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output.split('\n').length).toBe(100);
+    });
+  });
+});
+
+describe('SandboxClient', () => {
+  const testSocketPath = `/tmp/prodisco-client-test-${Date.now()}.sock`;
+  const testCacheDir = `/tmp/prodisco-cache-client-${Date.now()}`;
+  let server: grpc.Server;
+
+  beforeAll(async () => {
+    server = await startServer({
+      socketPath: testSocketPath,
+      cacheDir: testCacheDir,
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.tryShutdown((err) => {
+        if (err) {
+          server.forceShutdown();
+        }
+        resolve();
+      });
+    });
+
+    if (existsSync(testSocketPath)) {
+      try {
+        unlinkSync(testSocketPath);
+      } catch {
+        // Ignore
+      }
+    }
+
+    if (existsSync(testCacheDir)) {
+      rmSync(testCacheDir, { recursive: true });
+    }
+  });
+
+  describe('Constructor', () => {
+    it('uses provided socket path', () => {
+      const client = new SandboxClient({ socketPath: testSocketPath });
+      expect(client).toBeInstanceOf(SandboxClient);
+      client.close();
+    });
+
+    it('uses environment variable for socket path', () => {
+      const originalEnv = process.env.SANDBOX_SOCKET_PATH;
+      process.env.SANDBOX_SOCKET_PATH = testSocketPath;
+
+      const client = new SandboxClient();
+      expect(client).toBeInstanceOf(SandboxClient);
+      client.close();
+
+      if (originalEnv) {
+        process.env.SANDBOX_SOCKET_PATH = originalEnv;
+      } else {
+        delete process.env.SANDBOX_SOCKET_PATH;
+      }
+    });
+  });
+
+  describe('waitForHealthy', () => {
+    it('returns true when server is healthy', async () => {
+      const client = new SandboxClient({ socketPath: testSocketPath });
+
+      const result = await client.waitForHealthy(5000);
+      expect(result).toBe(true);
+
+      client.close();
+    });
+
+    it('returns false when timeout expires', async () => {
+      const client = new SandboxClient({ socketPath: '/tmp/non-existent-socket.sock' });
+
+      const result = await client.waitForHealthy(100, 50);
+      expect(result).toBe(false);
+
+      client.close();
+    });
+  });
+
+  describe('close', () => {
+    it('closes the client connection', () => {
+      const client = new SandboxClient({ socketPath: testSocketPath });
+      expect(() => client.close()).not.toThrow();
+    });
+  });
+});

--- a/packages/sandbox-server/src/__tests__/sandbox-service.test.ts
+++ b/packages/sandbox-server/src/__tests__/sandbox-service.test.ts
@@ -1,0 +1,534 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import * as grpc from '@grpc/grpc-js';
+import { createSandboxService, type SandboxServiceConfig } from '../server/sandbox-service.js';
+import type { ExecuteRequest, ExecuteResponse, HealthCheckRequest, HealthCheckResponse } from '../generated/sandbox.js';
+import { existsSync, rmSync } from 'node:fs';
+
+describe('SandboxService', () => {
+  const testCacheDir = '/tmp/prodisco-service-test-' + Date.now();
+
+  afterEach(() => {
+    if (existsSync(testCacheDir)) {
+      rmSync(testCacheDir, { recursive: true });
+    }
+  });
+
+  // Helper to create mock gRPC call objects
+  function createMockCall<T>(request: T): grpc.ServerUnaryCall<T, unknown> {
+    return {
+      request,
+      cancelled: false,
+      metadata: new grpc.Metadata(),
+      getPeer: () => 'test-peer',
+      getDeadline: () => Infinity,
+      sendMetadata: vi.fn(),
+    } as unknown as grpc.ServerUnaryCall<T, unknown>;
+  }
+
+  // Helper to promisify the callback-based handlers
+  function promisifyHandler<TReq, TRes>(
+    handler: (call: grpc.ServerUnaryCall<TReq, TRes>, callback: grpc.sendUnaryData<TRes>) => void | Promise<void>,
+    request: TReq
+  ): Promise<TRes> {
+    return new Promise((resolve, reject) => {
+      const call = createMockCall(request);
+      handler(call as any, (error, response) => {
+        if (error) {
+          reject(error);
+        } else if (response) {
+          resolve(response);
+        } else {
+          reject(new Error('No response'));
+        }
+      });
+    });
+  }
+
+  describe('createSandboxService', () => {
+    it('creates service with default config', () => {
+      const service = createSandboxService();
+
+      expect(service).toBeDefined();
+      expect(service).toHaveProperty('execute');
+      expect(service).toHaveProperty('healthCheck');
+      expect(typeof service.execute).toBe('function');
+      expect(typeof service.healthCheck).toBe('function');
+    });
+
+    it('creates service with custom config', () => {
+      const service = createSandboxService({
+        prometheusUrl: 'http://localhost:9090',
+        cacheDir: testCacheDir,
+      });
+
+      expect(service).toBeDefined();
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('returns healthy status', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const response = await promisifyHandler<HealthCheckRequest, HealthCheckResponse>(
+        service.healthCheck,
+        {}
+      );
+
+      expect(response.healthy).toBe(true);
+    });
+
+    it('returns kubernetes context', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const response = await promisifyHandler<HealthCheckRequest, HealthCheckResponse>(
+        service.healthCheck,
+        {}
+      );
+
+      expect(response.kubernetesContext).toBeDefined();
+      expect(typeof response.kubernetesContext).toBe('string');
+    });
+  });
+
+  describe('execute - Code Execution', () => {
+    it('executes simple code successfully', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const request: ExecuteRequest = {
+        source: { $case: 'code', code: 'console.log("hello")' },
+        timeoutMs: undefined,
+      };
+
+      const response = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        request
+      );
+
+      expect(response.success).toBe(true);
+      expect(response.output).toBe('hello');
+      expect(response.error).toBeUndefined();
+    });
+
+    it('returns execution time as string', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const request: ExecuteRequest = {
+        source: { $case: 'code', code: 'console.log("test")' },
+        timeoutMs: undefined,
+      };
+
+      const response = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        request
+      );
+
+      expect(response.executionTimeMs).toBeDefined();
+      expect(typeof response.executionTimeMs).toBe('string');
+      expect(parseInt(response.executionTimeMs)).toBeGreaterThanOrEqual(0);
+    });
+
+    it('handles execution errors', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const request: ExecuteRequest = {
+        source: { $case: 'code', code: 'throw new Error("test error")' },
+        timeoutMs: undefined,
+      };
+
+      const response = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        request
+      );
+
+      expect(response.success).toBe(false);
+      expect(response.error).toBe('test error');
+    });
+
+    it('respects custom timeout', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const request: ExecuteRequest = {
+        source: {
+          $case: 'code',
+          code: 'await new Promise(r => setTimeout(r, 5000)); console.log("done");'
+        },
+        timeoutMs: 100,
+      };
+
+      const response = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        request
+      );
+
+      expect(response.success).toBe(false);
+      expect(response.error).toBe('Script execution timed out');
+    });
+
+    it('uses default 30000ms timeout when not specified', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const request: ExecuteRequest = {
+        source: { $case: 'code', code: 'console.log("quick")' },
+        timeoutMs: undefined,
+      };
+
+      const response = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        request
+      );
+
+      expect(response.success).toBe(true);
+    });
+  });
+
+  describe('execute - Caching', () => {
+    it('caches successful executions', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const request: ExecuteRequest = {
+        source: { $case: 'code', code: 'console.log("cache me")' },
+        timeoutMs: undefined,
+      };
+
+      const response = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        request
+      );
+
+      expect(response.success).toBe(true);
+      expect(response.cachedAs).toBeDefined();
+      expect(response.cachedAs).toMatch(/^script-.*\.ts$/);
+    });
+
+    it('does not cache failed executions', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const request: ExecuteRequest = {
+        source: { $case: 'code', code: 'throw new Error("fail")' },
+        timeoutMs: undefined,
+      };
+
+      const response = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        request
+      );
+
+      expect(response.success).toBe(false);
+      expect(response.cachedAs).toBeUndefined();
+    });
+
+    it('does not duplicate cache for same code', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const request: ExecuteRequest = {
+        source: { $case: 'code', code: 'console.log("dedupe test")' },
+        timeoutMs: undefined,
+      };
+
+      const response1 = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        request
+      );
+
+      const response2 = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        request
+      );
+
+      expect(response1.success).toBe(true);
+      expect(response2.success).toBe(true);
+      expect(response1.cachedAs).toBeDefined();
+      // Second execution of same code should not create new cache
+      expect(response2.cachedAs).toBeUndefined();
+    });
+  });
+
+  describe('execute - Cached Script Execution', () => {
+    it('executes cached script by name', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      // First, cache some code
+      const cacheRequest: ExecuteRequest = {
+        source: { $case: 'code', code: 'console.log("cached script output")' },
+        timeoutMs: undefined,
+      };
+
+      const cacheResponse = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        cacheRequest
+      );
+
+      expect(cacheResponse.cachedAs).toBeDefined();
+
+      // Now execute the cached script
+      const executeRequest: ExecuteRequest = {
+        source: { $case: 'cached', cached: cacheResponse.cachedAs! },
+        timeoutMs: undefined,
+      };
+
+      const response = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        executeRequest
+      );
+
+      expect(response.success).toBe(true);
+      expect(response.output).toBe('cached script output');
+      // Should return the cached script name
+      expect(response.cachedAs).toBe(cacheResponse.cachedAs);
+    });
+
+    it('returns error for non-existent cached script', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const request: ExecuteRequest = {
+        source: { $case: 'cached', cached: 'non-existent-script' },
+        timeoutMs: undefined,
+      };
+
+      const response = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        request
+      );
+
+      expect(response.success).toBe(false);
+      expect(response.error).toContain('not found');
+      expect(response.output).toBe('');
+      expect(response.executionTimeMs).toBe('0');
+    });
+
+    it('finds cached script by partial name', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      // First, cache some code
+      const cacheRequest: ExecuteRequest = {
+        source: { $case: 'code', code: 'console.log("partial match test")' },
+        timeoutMs: undefined,
+      };
+
+      const cacheResponse = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        cacheRequest
+      );
+
+      expect(cacheResponse.cachedAs).toBeDefined();
+
+      // Extract the hash from the filename
+      const match = cacheResponse.cachedAs!.match(/-([a-f0-9]{12})\.ts$/);
+      expect(match).not.toBeNull();
+      const hash = match![1];
+
+      // Execute using just the hash
+      const executeRequest: ExecuteRequest = {
+        source: { $case: 'cached', cached: hash },
+        timeoutMs: undefined,
+      };
+
+      const response = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        executeRequest
+      );
+
+      expect(response.success).toBe(true);
+      expect(response.output).toBe('partial match test');
+    });
+  });
+
+  describe('execute - Source Validation', () => {
+    it('returns error when neither code nor cached is provided', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const request: ExecuteRequest = {
+        source: undefined,
+        timeoutMs: undefined,
+      };
+
+      const response = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        request
+      );
+
+      expect(response.success).toBe(false);
+      expect(response.error).toBe('Either code or cached must be provided');
+      expect(response.output).toBe('');
+      expect(response.executionTimeMs).toBe('0');
+    });
+  });
+
+  describe('execute - TypeScript Support', () => {
+    it('executes TypeScript code', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const request: ExecuteRequest = {
+        source: {
+          $case: 'code',
+          code: `
+            interface Person { name: string; age: number; }
+            const p: Person = { name: "Alice", age: 30 };
+            console.log(p.name, p.age);
+          `
+        },
+        timeoutMs: undefined,
+      };
+
+      const response = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        request
+      );
+
+      expect(response.success).toBe(true);
+      expect(response.output).toBe('Alice 30');
+    });
+  });
+
+  describe('execute - Async Support', () => {
+    it('executes async/await code', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const request: ExecuteRequest = {
+        source: {
+          $case: 'code',
+          code: `
+            const delay = (ms: number) => new Promise(r => setTimeout(r, ms));
+            console.log("start");
+            await delay(10);
+            console.log("end");
+          `
+        },
+        timeoutMs: undefined,
+      };
+
+      const response = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        request
+      );
+
+      expect(response.success).toBe(true);
+      expect(response.output).toBe('start\nend');
+    });
+  });
+
+  describe('execute - Kubernetes Context', () => {
+    it('provides k8s library in sandbox', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const request: ExecuteRequest = {
+        source: {
+          $case: 'code',
+          code: 'console.log(typeof k8s, typeof kc);'
+        },
+        timeoutMs: undefined,
+      };
+
+      const response = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        request
+      );
+
+      expect(response.success).toBe(true);
+      expect(response.output).toBe('object object');
+    });
+
+    it('provides pre-configured KubeConfig', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const request: ExecuteRequest = {
+        source: {
+          $case: 'code',
+          code: 'console.log(typeof kc.getCurrentContext);'
+        },
+        timeoutMs: undefined,
+      };
+
+      const response = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        request
+      );
+
+      expect(response.success).toBe(true);
+      expect(response.output).toBe('function');
+    });
+  });
+
+  describe('execute - Multiple Outputs', () => {
+    it('captures all console output', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const request: ExecuteRequest = {
+        source: {
+          $case: 'code',
+          code: `
+            console.log("line 1");
+            console.error("error line");
+            console.warn("warn line");
+            console.info("info line");
+            console.log("line 2");
+          `
+        },
+        timeoutMs: undefined,
+      };
+
+      const response = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        request
+      );
+
+      expect(response.success).toBe(true);
+      expect(response.output).toBe(
+        'line 1\n[ERROR] error line\n[WARN] warn line\n[INFO] info line\nline 2'
+      );
+    });
+  });
+
+  describe('execute - Edge Cases', () => {
+    it('handles empty code', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const request: ExecuteRequest = {
+        source: { $case: 'code', code: '' },
+        timeoutMs: undefined,
+      };
+
+      const response = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        request
+      );
+
+      expect(response.success).toBe(true);
+      expect(response.output).toBe('');
+    });
+
+    it('handles code with only comments', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const request: ExecuteRequest = {
+        source: { $case: 'code', code: '// just a comment' },
+        timeoutMs: undefined,
+      };
+
+      const response = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        request
+      );
+
+      expect(response.success).toBe(true);
+      expect(response.output).toBe('');
+    });
+
+    it('handles Unicode in code and output', async () => {
+      const service = createSandboxService({ cacheDir: testCacheDir });
+
+      const request: ExecuteRequest = {
+        source: { $case: 'code', code: 'console.log("Hello 世界 🌍")' },
+        timeoutMs: undefined,
+      };
+
+      const response = await promisifyHandler<ExecuteRequest, ExecuteResponse>(
+        service.execute,
+        request
+      );
+
+      expect(response.success).toBe(true);
+      expect(response.output).toBe('Hello 世界 🌍');
+    });
+  });
+});


### PR DESCRIPTION
- Add Executor tests (54 tests): TypeScript, async/await, timeout, sandbox context
- Add CacheManager tests (32 tests): caching, deduplication, finding scripts
- Add SandboxService tests (24 tests): gRPC handlers, health check, execution
- Add integration tests (34 tests): end-to-end client-server communication
- Add vitest as dev dependency to sandbox-server package

🤖 Generated with [Claude Code](https://claude.com/claude-code)