### PR TITLE
Add TCP transport support for gRPC sandbox server

### DIFF
--- a/docs/grpc-sandbox-architecture.md
+++ b/docs/grpc-sandbox-architecture.md
@@ -44,11 +44,18 @@ The sandbox server lives in `packages/sandbox-server/` as an npm workspace packa
 - Future extraction to a separate repository if needed
 - Independent versioning and deployment
 
-### 3. Unix Socket First
-Communication uses Unix domain sockets (`/tmp/prodisco-sandbox.sock`) for:
-- Low latency local execution
+### 3. Flexible Transport: Unix Socket or TCP
+Communication supports both Unix domain sockets and TCP:
+
+**Unix Socket (default)** - Best for local execution:
+- Low latency
 - Simple setup with no network configuration
-- TCP support can be added later for remote execution
+- Secure by default (file system permissions)
+
+**TCP Transport** - Enables remote execution:
+- Connect to sandbox servers on different hosts
+- Suitable for containerized deployments
+- Configurable via options or environment variables
 
 ### 4. Language-Agnostic Protocol
 The gRPC protocol is designed to be language-agnostic:
@@ -395,6 +402,9 @@ User → MCP Server → runSandbox Tool → gRPC Client
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SANDBOX_SOCKET_PATH` | `/tmp/prodisco-sandbox.sock` | Unix socket path |
+| `SANDBOX_USE_TCP` | `false` | Use TCP transport instead of Unix socket (`true` or `1`) |
+| `SANDBOX_TCP_HOST` | `0.0.0.0` (server) / `localhost` (client) | TCP host to bind/connect to |
+| `SANDBOX_TCP_PORT` | `50051` | TCP port to bind/connect to |
 | `SCRIPTS_CACHE_DIR` | `/tmp/prodisco-scripts` | Directory for cached scripts |
 | `PROMETHEUS_URL` | (none) | Prometheus server URL |
 | `KUBECONFIG` | `~/.kube/config` | Kubernetes config path |
@@ -423,17 +433,64 @@ Run tests with:
 npm test
 ```
 
-## Future Enhancements
+## TCP Transport
 
-### TCP Transport
-Add TCP support for remote sandbox servers:
+The sandbox server supports TCP transport for remote execution. This enables running the sandbox server on a different host or in a container.
+
+### Server Configuration
+
+Start the server with TCP transport:
+
 ```typescript
-// Client
-new SandboxServiceClient('sandbox.example.com:50051', credentials);
+// Programmatic configuration
+import { startServer } from '@prodisco/sandbox-server';
 
-// Server
-server.bindAsync('0.0.0.0:50051', credentials, callback);
+await startServer({
+  useTcp: true,
+  tcpHost: '0.0.0.0',  // Bind to all interfaces
+  tcpPort: 50051,
+});
+
+// Or using environment variables
+// SANDBOX_USE_TCP=true SANDBOX_TCP_HOST=0.0.0.0 SANDBOX_TCP_PORT=50051 node server.js
 ```
+
+### Client Configuration
+
+Connect to a remote sandbox server:
+
+```typescript
+import { SandboxClient } from '@prodisco/sandbox-server';
+
+// Explicit TCP configuration
+const client = new SandboxClient({
+  useTcp: true,
+  tcpHost: 'sandbox.example.com',
+  tcpPort: 50051,
+});
+
+// Or infer TCP from host/port (useTcp is optional when host/port are specified)
+const client2 = new SandboxClient({
+  tcpHost: 'sandbox.example.com',
+  tcpPort: 50051,
+});
+
+// Or using environment variables
+// SANDBOX_USE_TCP=true SANDBOX_TCP_HOST=sandbox.example.com SANDBOX_TCP_PORT=50051
+const client3 = new SandboxClient();
+```
+
+### Choosing Between Unix Socket and TCP
+
+| Use Case | Recommended Transport |
+|----------|----------------------|
+| Local development | Unix socket (default) |
+| MCP server and sandbox on same host | Unix socket |
+| Sandbox in separate container | TCP |
+| Sandbox on remote host | TCP |
+| Production with network isolation | TCP with TLS (see Future Enhancements) |
+
+## Future Enhancements
 
 ### TLS/mTLS
 Secure communication for production deployments:

--- a/packages/sandbox-server/src/__tests__/sandbox-service.test.ts
+++ b/packages/sandbox-server/src/__tests__/sandbox-service.test.ts
@@ -219,9 +219,11 @@ describe('SandboxService', () => {
 
     it('does not duplicate cache for same code', async () => {
       const service = createSandboxService({ cacheDir: testCacheDir });
+      // Use unique code to avoid collisions with other tests
+      const uniqueCode = `console.log("dedupe test ${Date.now()}-${Math.random().toString(36).slice(2)}")`;
 
       const request: ExecuteRequest = {
-        source: { $case: 'code', code: 'console.log("dedupe test")' },
+        source: { $case: 'code', code: uniqueCode },
         timeoutMs: undefined,
       };
 

--- a/packages/sandbox-server/src/__tests__/tcp-transport.test.ts
+++ b/packages/sandbox-server/src/__tests__/tcp-transport.test.ts
@@ -1,0 +1,675 @@
+import { describe, expect, it, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import * as grpc from '@grpc/grpc-js';
+import { rmSync, existsSync } from 'node:fs';
+import { startServer } from '../server/index.js';
+import { SandboxClient } from '../client/index.js';
+
+// Helper to generate unique IDs for test isolation
+const uniqueId = () => `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+describe('TCP Transport', () => {
+  const testPort = 50052 + Math.floor(Math.random() * 1000);
+  const testHost = '127.0.0.1';
+  const testCacheDir = `/tmp/prodisco-cache-tcp-${uniqueId()}`;
+  let server: grpc.Server;
+  let client: SandboxClient;
+
+  beforeAll(async () => {
+    // Start server with TCP transport
+    server = await startServer({
+      useTcp: true,
+      tcpHost: testHost,
+      tcpPort: testPort,
+      cacheDir: testCacheDir,
+    });
+
+    // Create client with TCP transport
+    client = new SandboxClient({
+      useTcp: true,
+      tcpHost: testHost,
+      tcpPort: testPort,
+    });
+
+    // Wait for server to be healthy
+    const healthy = await client.waitForHealthy(5000);
+    expect(healthy).toBe(true);
+  });
+
+  afterAll(async () => {
+    // Close client
+    client.close();
+
+    // Shutdown server
+    await new Promise<void>((resolve) => {
+      server.tryShutdown((err) => {
+        if (err) {
+          server.forceShutdown();
+        }
+        resolve();
+      });
+    });
+  });
+
+  describe('Health Check over TCP', () => {
+    it('returns healthy status', async () => {
+      const result = await client.healthCheck();
+
+      expect(result.healthy).toBe(true);
+    });
+
+    it('returns kubernetes context', async () => {
+      const result = await client.healthCheck();
+
+      expect(result.kubernetesContext).toBeDefined();
+      expect(typeof result.kubernetesContext).toBe('string');
+    });
+  });
+
+  describe('Code Execution over TCP', () => {
+    it('executes simple code', async () => {
+      const result = await client.execute({
+        code: 'console.log("hello from TCP")',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('hello from TCP');
+      expect(result.error).toBeUndefined();
+    });
+
+    it('handles TypeScript code', async () => {
+      const result = await client.execute({
+        code: `
+          interface User { name: string; }
+          const user: User = { name: "TCP Test" };
+          console.log(user.name);
+        `,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('TCP Test');
+    });
+
+    it('handles async code', async () => {
+      const result = await client.execute({
+        code: `
+          await new Promise(r => setTimeout(r, 10));
+          console.log("async TCP complete");
+        `,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('async TCP complete');
+    });
+
+    it('handles execution errors', async () => {
+      const result = await client.execute({
+        code: 'throw new Error("TCP error")',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('TCP error');
+    });
+
+    it('respects timeout', async () => {
+      const result = await client.execute({
+        code: 'await new Promise(r => setTimeout(r, 10000))',
+        timeoutMs: 100,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Script execution timed out');
+    });
+  });
+
+  describe('Concurrent Requests over TCP', () => {
+    it('handles multiple concurrent executions', async () => {
+      const requests = Array.from({ length: 10 }, (_, i) => ({
+        code: `console.log("tcp concurrent ${i}")`,
+      }));
+
+      const results = await Promise.all(
+        requests.map(req => client.execute(req))
+      );
+
+      expect(results.every(r => r.success)).toBe(true);
+      results.forEach((result, i) => {
+        expect(result.output).toBe(`tcp concurrent ${i}`);
+      });
+    });
+  });
+});
+
+describe('TCP Transport with Environment Variables', () => {
+  const testPort = 50053 + Math.floor(Math.random() * 1000);
+  const testHost = '127.0.0.1';
+  const testCacheDir = `/tmp/prodisco-cache-tcp-env-${uniqueId()}`;
+  let server: grpc.Server;
+  let client: SandboxClient;
+
+  let originalTcpHost: string | undefined;
+  let originalTcpPort: string | undefined;
+  let originalUseTcp: string | undefined;
+
+  beforeAll(async () => {
+    // Save original env vars
+    originalTcpHost = process.env.SANDBOX_TCP_HOST;
+    originalTcpPort = process.env.SANDBOX_TCP_PORT;
+    originalUseTcp = process.env.SANDBOX_USE_TCP;
+
+    // Set env vars
+    process.env.SANDBOX_TCP_HOST = testHost;
+    process.env.SANDBOX_TCP_PORT = String(testPort);
+    process.env.SANDBOX_USE_TCP = 'true';
+
+    // Start server using env vars
+    server = await startServer({
+      cacheDir: testCacheDir,
+    });
+
+    // Create client using env vars
+    client = new SandboxClient();
+
+    // Wait for server to be healthy
+    const healthy = await client.waitForHealthy(5000);
+    expect(healthy).toBe(true);
+  });
+
+  afterAll(async () => {
+    // Close client
+    client.close();
+
+    // Shutdown server
+    await new Promise<void>((resolve) => {
+      server.tryShutdown((err) => {
+        if (err) {
+          server.forceShutdown();
+        }
+        resolve();
+      });
+    });
+
+    // Restore original env vars
+    if (originalTcpHost !== undefined) {
+      process.env.SANDBOX_TCP_HOST = originalTcpHost;
+    } else {
+      delete process.env.SANDBOX_TCP_HOST;
+    }
+    if (originalTcpPort !== undefined) {
+      process.env.SANDBOX_TCP_PORT = originalTcpPort;
+    } else {
+      delete process.env.SANDBOX_TCP_PORT;
+    }
+    if (originalUseTcp !== undefined) {
+      process.env.SANDBOX_USE_TCP = originalUseTcp;
+    } else {
+      delete process.env.SANDBOX_USE_TCP;
+    }
+  });
+
+  it('connects using environment variables', async () => {
+    const result = await client.healthCheck();
+    expect(result.healthy).toBe(true);
+  });
+
+  it('executes code over TCP configured by env vars', async () => {
+    const result = await client.execute({
+      code: 'console.log("env var TCP")',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe('env var TCP');
+  });
+});
+
+describe('SandboxClient TCP Options', () => {
+  it('uses TCP when useTcp is true', () => {
+    const client = new SandboxClient({ useTcp: true });
+    expect(client).toBeInstanceOf(SandboxClient);
+    client.close();
+  });
+
+  it('uses TCP when tcpHost is specified', () => {
+    const client = new SandboxClient({ tcpHost: 'localhost' });
+    expect(client).toBeInstanceOf(SandboxClient);
+    client.close();
+  });
+
+  it('uses TCP when tcpPort is specified', () => {
+    const client = new SandboxClient({ tcpPort: 50051 });
+    expect(client).toBeInstanceOf(SandboxClient);
+    client.close();
+  });
+
+  it('uses Unix socket by default', () => {
+    const client = new SandboxClient({ socketPath: '/tmp/test.sock' });
+    expect(client).toBeInstanceOf(SandboxClient);
+    client.close();
+  });
+
+  it('waitForHealthy returns false for non-existent TCP server', async () => {
+    const client = new SandboxClient({
+      useTcp: true,
+      tcpHost: 'localhost',
+      tcpPort: 59999, // Unlikely to be in use
+    });
+
+    const result = await client.waitForHealthy(100, 50);
+    expect(result).toBe(false);
+
+    client.close();
+  });
+});
+
+describe('TCP Transport - Script Caching', () => {
+  const testPort = 50054 + Math.floor(Math.random() * 1000);
+  const testHost = '127.0.0.1';
+  const testCacheDir = `/tmp/prodisco-cache-tcp-caching-${uniqueId()}`;
+  let server: grpc.Server;
+  let client: SandboxClient;
+
+  beforeAll(async () => {
+    server = await startServer({
+      useTcp: true,
+      tcpHost: testHost,
+      tcpPort: testPort,
+      cacheDir: testCacheDir,
+    });
+
+    client = new SandboxClient({
+      useTcp: true,
+      tcpHost: testHost,
+      tcpPort: testPort,
+    });
+
+    await client.waitForHealthy(5000);
+  });
+
+  afterAll(async () => {
+    client.close();
+
+    await new Promise<void>((resolve) => {
+      server.tryShutdown((err) => {
+        if (err) server.forceShutdown();
+        resolve();
+      });
+    });
+
+    if (existsSync(testCacheDir)) {
+      rmSync(testCacheDir, { recursive: true });
+    }
+  });
+
+  it('caches successful executions over TCP', async () => {
+    const code = `console.log("tcp cache test ${uniqueId()}")`;
+    const result = await client.execute({ code });
+
+    expect(result.success).toBe(true);
+    expect(result.cachedAs).toBeDefined();
+    expect(result.cachedAs).toMatch(/^script-.*\.ts$/);
+  });
+
+  it('can execute cached scripts over TCP', async () => {
+    const uniqueValue = `tcp-cached-${uniqueId()}`;
+    const code = `console.log("${uniqueValue}")`;
+
+    // First execution - gets cached
+    const firstResult = await client.execute({ code });
+    expect(firstResult.success).toBe(true);
+    expect(firstResult.cachedAs).toBeDefined();
+
+    // Execute from cache
+    const cachedResult = await client.execute({
+      cached: firstResult.cachedAs!,
+    });
+
+    expect(cachedResult.success).toBe(true);
+    expect(cachedResult.output).toBe(uniqueValue);
+  });
+
+  it('returns error for non-existent cached script over TCP', async () => {
+    const result = await client.execute({
+      cached: 'non-existent-tcp-script-12345',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not found');
+  });
+});
+
+describe('TCP Transport - Server Binding Options', () => {
+  it('binds to localhost', async () => {
+    const testPort = 50055 + Math.floor(Math.random() * 1000);
+    const testCacheDir = `/tmp/prodisco-cache-tcp-localhost-${uniqueId()}`;
+
+    const server = await startServer({
+      useTcp: true,
+      tcpHost: 'localhost',
+      tcpPort: testPort,
+      cacheDir: testCacheDir,
+    });
+
+    const client = new SandboxClient({
+      useTcp: true,
+      tcpHost: 'localhost',
+      tcpPort: testPort,
+    });
+
+    const healthy = await client.waitForHealthy(5000);
+    expect(healthy).toBe(true);
+
+    const result = await client.execute({ code: 'console.log("localhost test")' });
+    expect(result.success).toBe(true);
+    expect(result.output).toBe('localhost test');
+
+    client.close();
+    await new Promise<void>((resolve) => {
+      server.tryShutdown((err) => {
+        if (err) server.forceShutdown();
+        resolve();
+      });
+    });
+
+    if (existsSync(testCacheDir)) {
+      rmSync(testCacheDir, { recursive: true });
+    }
+  });
+
+  it('binds to 0.0.0.0', async () => {
+    const testPort = 50056 + Math.floor(Math.random() * 1000);
+    const testCacheDir = `/tmp/prodisco-cache-tcp-allif-${uniqueId()}`;
+
+    const server = await startServer({
+      useTcp: true,
+      tcpHost: '0.0.0.0',
+      tcpPort: testPort,
+      cacheDir: testCacheDir,
+    });
+
+    // Connect via 127.0.0.1 (should work since server binds to all interfaces)
+    const client = new SandboxClient({
+      useTcp: true,
+      tcpHost: '127.0.0.1',
+      tcpPort: testPort,
+    });
+
+    const healthy = await client.waitForHealthy(5000);
+    expect(healthy).toBe(true);
+
+    const result = await client.execute({ code: 'console.log("0.0.0.0 test")' });
+    expect(result.success).toBe(true);
+    expect(result.output).toBe('0.0.0.0 test');
+
+    client.close();
+    await new Promise<void>((resolve) => {
+      server.tryShutdown((err) => {
+        if (err) server.forceShutdown();
+        resolve();
+      });
+    });
+
+    if (existsSync(testCacheDir)) {
+      rmSync(testCacheDir, { recursive: true });
+    }
+  });
+});
+
+describe('TCP Transport - Environment Variable Priority', () => {
+  let originalSocketPath: string | undefined;
+  let originalTcpHost: string | undefined;
+  let originalTcpPort: string | undefined;
+  let originalUseTcp: string | undefined;
+
+  beforeEach(() => {
+    // Save original env vars
+    originalSocketPath = process.env.SANDBOX_SOCKET_PATH;
+    originalTcpHost = process.env.SANDBOX_TCP_HOST;
+    originalTcpPort = process.env.SANDBOX_TCP_PORT;
+    originalUseTcp = process.env.SANDBOX_USE_TCP;
+
+    // Clear all env vars
+    delete process.env.SANDBOX_SOCKET_PATH;
+    delete process.env.SANDBOX_TCP_HOST;
+    delete process.env.SANDBOX_TCP_PORT;
+    delete process.env.SANDBOX_USE_TCP;
+  });
+
+  afterEach(() => {
+    // Restore original env vars
+    if (originalSocketPath !== undefined) {
+      process.env.SANDBOX_SOCKET_PATH = originalSocketPath;
+    } else {
+      delete process.env.SANDBOX_SOCKET_PATH;
+    }
+    if (originalTcpHost !== undefined) {
+      process.env.SANDBOX_TCP_HOST = originalTcpHost;
+    } else {
+      delete process.env.SANDBOX_TCP_HOST;
+    }
+    if (originalTcpPort !== undefined) {
+      process.env.SANDBOX_TCP_PORT = originalTcpPort;
+    } else {
+      delete process.env.SANDBOX_TCP_PORT;
+    }
+    if (originalUseTcp !== undefined) {
+      process.env.SANDBOX_USE_TCP = originalUseTcp;
+    } else {
+      delete process.env.SANDBOX_USE_TCP;
+    }
+  });
+
+  it('explicit useTcp=false overrides env vars', async () => {
+    const testPort = 50057 + Math.floor(Math.random() * 1000);
+    const id = uniqueId();
+    const testSocketPath = `/tmp/prodisco-test-priority-${id}.sock`;
+    const testCacheDir = `/tmp/prodisco-cache-priority-${id}`;
+
+    // Set env vars to use TCP
+    process.env.SANDBOX_USE_TCP = 'true';
+    process.env.SANDBOX_TCP_HOST = '127.0.0.1';
+    process.env.SANDBOX_TCP_PORT = String(testPort);
+
+    // But explicitly set useTcp=false - should use Unix socket
+    const server = await startServer({
+      useTcp: false,
+      socketPath: testSocketPath,
+      cacheDir: testCacheDir,
+    });
+
+    const client = new SandboxClient({
+      useTcp: false,
+      socketPath: testSocketPath,
+    });
+
+    const healthy = await client.waitForHealthy(5000);
+    expect(healthy).toBe(true);
+
+    client.close();
+    await new Promise<void>((resolve) => {
+      server.tryShutdown((err) => {
+        if (err) server.forceShutdown();
+        resolve();
+      });
+    });
+
+    // Clean up socket file
+    if (existsSync(testSocketPath)) {
+      rmSync(testSocketPath);
+    }
+    if (existsSync(testCacheDir)) {
+      rmSync(testCacheDir, { recursive: true });
+    }
+  });
+
+  it('SANDBOX_USE_TCP=1 enables TCP', async () => {
+    const testPort = 50058 + Math.floor(Math.random() * 1000);
+    const testCacheDir = `/tmp/prodisco-cache-usetcp1-${uniqueId()}`;
+
+    process.env.SANDBOX_USE_TCP = '1';
+    process.env.SANDBOX_TCP_HOST = '127.0.0.1';
+    process.env.SANDBOX_TCP_PORT = String(testPort);
+
+    const server = await startServer({ cacheDir: testCacheDir });
+    const client = new SandboxClient();
+
+    const healthy = await client.waitForHealthy(5000);
+    expect(healthy).toBe(true);
+
+    const result = await client.execute({ code: 'console.log("USE_TCP=1")' });
+    expect(result.success).toBe(true);
+
+    client.close();
+    await new Promise<void>((resolve) => {
+      server.tryShutdown((err) => {
+        if (err) server.forceShutdown();
+        resolve();
+      });
+    });
+
+    if (existsSync(testCacheDir)) {
+      rmSync(testCacheDir, { recursive: true });
+    }
+  });
+
+  it('setting only SANDBOX_TCP_HOST implies TCP', async () => {
+    const testPort = 50059 + Math.floor(Math.random() * 1000);
+    const testCacheDir = `/tmp/prodisco-cache-hostimplies-${uniqueId()}`;
+
+    // Only set host, not USE_TCP
+    process.env.SANDBOX_TCP_HOST = '127.0.0.1';
+    process.env.SANDBOX_TCP_PORT = String(testPort);
+
+    const server = await startServer({ cacheDir: testCacheDir });
+    const client = new SandboxClient();
+
+    const healthy = await client.waitForHealthy(5000);
+    expect(healthy).toBe(true);
+
+    client.close();
+    await new Promise<void>((resolve) => {
+      server.tryShutdown((err) => {
+        if (err) server.forceShutdown();
+        resolve();
+      });
+    });
+
+    if (existsSync(testCacheDir)) {
+      rmSync(testCacheDir, { recursive: true });
+    }
+  });
+
+  it('setting only SANDBOX_TCP_PORT implies TCP', async () => {
+    const testPort = 50060 + Math.floor(Math.random() * 1000);
+    const testCacheDir = `/tmp/prodisco-cache-portimplies-${uniqueId()}`;
+
+    // Only set port, not USE_TCP or HOST
+    process.env.SANDBOX_TCP_PORT = String(testPort);
+
+    const server = await startServer({ cacheDir: testCacheDir });
+
+    // Client needs to know the port too
+    const client = new SandboxClient();
+
+    const healthy = await client.waitForHealthy(5000);
+    expect(healthy).toBe(true);
+
+    client.close();
+    await new Promise<void>((resolve) => {
+      server.tryShutdown((err) => {
+        if (err) server.forceShutdown();
+        resolve();
+      });
+    });
+
+    if (existsSync(testCacheDir)) {
+      rmSync(testCacheDir, { recursive: true });
+    }
+  });
+});
+
+describe('TCP Transport - Multiple Clients', () => {
+  const testPort = 50061 + Math.floor(Math.random() * 1000);
+  const testHost = '127.0.0.1';
+  const testCacheDir = `/tmp/prodisco-cache-tcp-multiclient-${uniqueId()}`;
+  let server: grpc.Server;
+
+  beforeAll(async () => {
+    server = await startServer({
+      useTcp: true,
+      tcpHost: testHost,
+      tcpPort: testPort,
+      cacheDir: testCacheDir,
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.tryShutdown((err) => {
+        if (err) server.forceShutdown();
+        resolve();
+      });
+    });
+
+    if (existsSync(testCacheDir)) {
+      rmSync(testCacheDir, { recursive: true });
+    }
+  });
+
+  it('handles multiple independent clients', async () => {
+    const clients = Array.from({ length: 3 }, () =>
+      new SandboxClient({
+        useTcp: true,
+        tcpHost: testHost,
+        tcpPort: testPort,
+      })
+    );
+
+    // Wait for all clients to be healthy
+    const healthChecks = await Promise.all(
+      clients.map(client => client.waitForHealthy(5000))
+    );
+    expect(healthChecks.every(h => h)).toBe(true);
+
+    // Execute code from each client concurrently
+    const results = await Promise.all(
+      clients.map((client, i) =>
+        client.execute({ code: `console.log("client ${i}")` })
+      )
+    );
+
+    expect(results.every(r => r.success)).toBe(true);
+    results.forEach((result, i) => {
+      expect(result.output).toBe(`client ${i}`);
+    });
+
+    // Close all clients
+    clients.forEach(client => client.close());
+  });
+
+  it('handles client reconnection after close', async () => {
+    const client1 = new SandboxClient({
+      useTcp: true,
+      tcpHost: testHost,
+      tcpPort: testPort,
+    });
+
+    await client1.waitForHealthy(5000);
+    const result1 = await client1.execute({ code: 'console.log("first")' });
+    expect(result1.success).toBe(true);
+
+    client1.close();
+
+    // Create new client after closing the first one
+    const client2 = new SandboxClient({
+      useTcp: true,
+      tcpHost: testHost,
+      tcpPort: testPort,
+    });
+
+    await client2.waitForHealthy(5000);
+    const result2 = await client2.execute({ code: 'console.log("second")' });
+    expect(result2.success).toBe(true);
+    expect(result2.output).toBe('second');
+
+    client2.close();
+  });
+});

--- a/packages/sandbox-server/src/client/index.ts
+++ b/packages/sandbox-server/src/client/index.ts
@@ -7,9 +7,18 @@ import {
 } from '../generated/sandbox.js';
 
 const DEFAULT_SOCKET_PATH = '/tmp/prodisco-sandbox.sock';
+const DEFAULT_TCP_HOST = 'localhost';
+const DEFAULT_TCP_PORT = 50051;
 
 export interface SandboxClientOptions {
+  /** Unix socket path for local connections */
   socketPath?: string;
+  /** TCP host to connect to (e.g., 'localhost', 'sandbox.example.com') */
+  tcpHost?: string;
+  /** TCP port to connect to */
+  tcpPort?: number;
+  /** Use TCP transport instead of Unix socket */
+  useTcp?: boolean;
 }
 
 export interface ExecuteOptions {
@@ -27,16 +36,58 @@ export interface ExecuteResult {
 }
 
 /**
+ * Determine if TCP transport should be used based on options and environment.
+ */
+function shouldUseTcp(options: SandboxClientOptions): boolean {
+  if (options.useTcp !== undefined) {
+    return options.useTcp;
+  }
+  // Check environment variable
+  const envUseTcp = process.env.SANDBOX_USE_TCP;
+  if (envUseTcp !== undefined) {
+    return envUseTcp === 'true' || envUseTcp === '1';
+  }
+  // Check if TCP host or port is specified
+  if (options.tcpHost || options.tcpPort || process.env.SANDBOX_TCP_HOST || process.env.SANDBOX_TCP_PORT) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Get the connection address based on options.
+ */
+function getConnectionAddress(options: SandboxClientOptions): string {
+  if (shouldUseTcp(options)) {
+    const host = options.tcpHost || process.env.SANDBOX_TCP_HOST || DEFAULT_TCP_HOST;
+    const port = options.tcpPort || parseInt(process.env.SANDBOX_TCP_PORT || '', 10) || DEFAULT_TCP_PORT;
+    return `${host}:${port}`;
+  }
+
+  const socketPath = options.socketPath || process.env.SANDBOX_SOCKET_PATH || DEFAULT_SOCKET_PATH;
+  return `unix://${socketPath}`;
+}
+
+/**
  * SandboxClient provides a high-level interface to the gRPC sandbox server.
+ *
+ * Supports both Unix socket (default) and TCP transport.
+ *
+ * Unix socket (default):
+ *   new SandboxClient({ socketPath: '/tmp/sandbox.sock' })
+ *
+ * TCP transport:
+ *   new SandboxClient({ useTcp: true, tcpHost: 'localhost', tcpPort: 50051 })
+ *   new SandboxClient({ tcpHost: 'sandbox.example.com', tcpPort: 50051 })
  */
 export class SandboxClient {
   private client: SandboxServiceClient;
 
   constructor(options: SandboxClientOptions = {}) {
-    const socketPath = options.socketPath || process.env.SANDBOX_SOCKET_PATH || DEFAULT_SOCKET_PATH;
+    const address = getConnectionAddress(options);
 
     this.client = new SandboxServiceClient(
-      `unix://${socketPath}`,
+      address,
       grpc.credentials.createInsecure(),
       {
         'grpc.keepalive_time_ms': 10000,

--- a/packages/sandbox-server/src/server/index.ts
+++ b/packages/sandbox-server/src/server/index.ts
@@ -6,9 +6,18 @@ import { SandboxServiceService } from '../generated/sandbox.js';
 import { createSandboxService } from './sandbox-service.js';
 
 const DEFAULT_SOCKET_PATH = '/tmp/prodisco-sandbox.sock';
+const DEFAULT_TCP_HOST = '0.0.0.0';
+const DEFAULT_TCP_PORT = 50051;
 
 export interface ServerConfig {
+  /** Unix socket path for local connections */
   socketPath?: string;
+  /** TCP host to bind to (e.g., '0.0.0.0', 'localhost') */
+  tcpHost?: string;
+  /** TCP port to bind to */
+  tcpPort?: number;
+  /** Use TCP transport instead of Unix socket */
+  useTcp?: boolean;
   prometheusUrl?: string;
   cacheDir?: string;
 }
@@ -30,13 +39,57 @@ function cleanupSocket(socketPath: string): void {
 }
 
 /**
+ * Determine if TCP transport should be used based on config and environment.
+ */
+function shouldUseTcp(config: ServerConfig): boolean {
+  if (config.useTcp !== undefined) {
+    return config.useTcp;
+  }
+  // Check environment variable
+  const envUseTcp = process.env.SANDBOX_USE_TCP;
+  if (envUseTcp !== undefined) {
+    return envUseTcp === 'true' || envUseTcp === '1';
+  }
+  // Check if TCP host or port is specified
+  if (config.tcpHost || config.tcpPort || process.env.SANDBOX_TCP_HOST || process.env.SANDBOX_TCP_PORT) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Get the binding address based on configuration.
+ */
+function getBindAddress(config: ServerConfig): { address: string; isUnixSocket: boolean } {
+  if (shouldUseTcp(config)) {
+    const host = config.tcpHost || process.env.SANDBOX_TCP_HOST || DEFAULT_TCP_HOST;
+    const port = config.tcpPort || parseInt(process.env.SANDBOX_TCP_PORT || '', 10) || DEFAULT_TCP_PORT;
+    return { address: `${host}:${port}`, isUnixSocket: false };
+  }
+
+  const socketPath = config.socketPath || process.env.SANDBOX_SOCKET_PATH || DEFAULT_SOCKET_PATH;
+  return { address: `unix://${socketPath}`, isUnixSocket: true };
+}
+
+/**
  * Start the gRPC sandbox server.
+ *
+ * Supports both Unix socket (default) and TCP transport.
+ *
+ * Unix socket (default):
+ *   startServer({ socketPath: '/tmp/sandbox.sock' })
+ *
+ * TCP transport:
+ *   startServer({ useTcp: true, tcpHost: '0.0.0.0', tcpPort: 50051 })
  */
 export async function startServer(config: ServerConfig = {}): Promise<grpc.Server> {
-  const socketPath = config.socketPath || process.env.SANDBOX_SOCKET_PATH || DEFAULT_SOCKET_PATH;
+  const { address, isUnixSocket } = getBindAddress(config);
 
-  // Clean up existing socket
-  cleanupSocket(socketPath);
+  // Clean up existing socket file if using Unix socket
+  if (isUnixSocket) {
+    const socketPath = address.replace('unix://', '');
+    cleanupSocket(socketPath);
+  }
 
   const server = new grpc.Server();
 
@@ -50,14 +103,14 @@ export async function startServer(config: ServerConfig = {}): Promise<grpc.Serve
 
   return new Promise((resolve, reject) => {
     server.bindAsync(
-      `unix://${socketPath}`,
+      address,
       grpc.ServerCredentials.createInsecure(),
       (error) => {
         if (error) {
           reject(error);
           return;
         }
-        console.log(`Sandbox gRPC server listening on unix://${socketPath}`);
+        console.log(`Sandbox gRPC server listening on ${address}`);
         resolve(server);
       }
     );
@@ -67,7 +120,7 @@ export async function startServer(config: ServerConfig = {}): Promise<grpc.Serve
 /**
  * Graceful shutdown handler.
  */
-function setupShutdown(server: grpc.Server, socketPath: string): void {
+function setupShutdown(server: grpc.Server, socketPath: string | null): void {
   const shutdown = (signal: string) => {
     console.log(`Received ${signal}, shutting down...`);
 
@@ -77,8 +130,10 @@ function setupShutdown(server: grpc.Server, socketPath: string): void {
         server.forceShutdown();
       }
 
-      // Clean up socket file
-      cleanupSocket(socketPath);
+      // Clean up socket file (only for Unix socket)
+      if (socketPath) {
+        cleanupSocket(socketPath);
+      }
 
       console.log('Server shut down');
       process.exit(0);
@@ -88,7 +143,9 @@ function setupShutdown(server: grpc.Server, socketPath: string): void {
     setTimeout(() => {
       console.warn('Forced shutdown after timeout');
       server.forceShutdown();
-      cleanupSocket(socketPath);
+      if (socketPath) {
+        cleanupSocket(socketPath);
+      }
       process.exit(1);
     }, 10000);
   };
@@ -102,9 +159,11 @@ const isMainModule = process.argv[1] === fileURLToPath(import.meta.url) ||
   process.argv[1]?.endsWith('/sandbox-server/dist/server/index.js');
 
 if (isMainModule) {
-  const socketPath = process.env.SANDBOX_SOCKET_PATH || DEFAULT_SOCKET_PATH;
+  const config: ServerConfig = {};
+  const { address, isUnixSocket } = getBindAddress(config);
+  const socketPath = isUnixSocket ? address.replace('unix://', '') : null;
 
-  startServer({ socketPath })
+  startServer(config)
     .then((server) => {
       setupShutdown(server, socketPath);
       console.log('Sandbox server started');

--- a/src/__tests__/runSandbox.test.ts
+++ b/src/__tests__/runSandbox.test.ts
@@ -412,7 +412,7 @@ describe('kubernetes.runSandbox', () => {
 
       // Check that a script was cached
       const files = readdirSync(SCRIPTS_CACHE_DIR);
-      const cachedScript = files.find(f => f.includes(uniqueId.toString().slice(-8)));
+      const _cachedScript = files.find(f => f.includes(uniqueId.toString().slice(-8)));
 
       // May or may not find by ID, but cache should have scripts
       expect(files.length).toBeGreaterThan(0);
@@ -446,12 +446,12 @@ describe('kubernetes.runSandbox', () => {
     });
 
     it('deduplicates scripts with identical content', async () => {
+      // Use unique code to avoid collisions with other tests or runs
+      const uniqueId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
       const code = `
-        // Deduplication test script
-        console.log("same content");
+        // Deduplication test script ${uniqueId}
+        console.log("same content ${uniqueId}");
       `;
-
-      const beforeCount = readdirSync(SCRIPTS_CACHE_DIR).length;
 
       // Execute same code twice
       await runSandbox({ code });


### PR DESCRIPTION
- Add TCP transport as alternative to Unix socket for remote sandbox servers
- Support configuration via options or environment variables:
  - SANDBOX_USE_TCP: Enable TCP transport (true/1)
  - SANDBOX_TCP_HOST: TCP host to bind/connect to
  - SANDBOX_TCP_PORT: TCP port to bind/connect to
- Update server to support both Unix socket and TCP binding
- Update client to support both Unix socket and TCP connection
- Add comprehensive tests for TCP transport (26 new tests)
- Fix flaky deduplication tests by using unique code per test run
- Update architecture documentation with TCP transport details

🤖 Generated with [Claude Code](https://claude.com/claude-code)