### PR TITLE
Add container isolation and CI integration tests for sandbox-server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,41 @@ jobs:
       - run: npm run build
       - run: npm run test
 
+  container-integration:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build packages
+        run: |
+          npm run proto:generate -w @prodisco/sandbox-server
+          npm run build -w @prodisco/sandbox-server
+          npm run build
+
+      - name: Install kind
+        uses: helm/kind-action@v1
+        with:
+          install_only: true
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Run container integration tests
+        run: ./scripts/integration/run-container-integration.sh
+
+      - name: Upload artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: container-integration-artifacts
+          path: artifacts/container-integration/
+          retention-days: 7

--- a/packages/sandbox-server/Dockerfile
+++ b/packages/sandbox-server/Dockerfile
@@ -1,0 +1,47 @@
+# Build stage
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+# Copy package files for dependency installation
+COPY package.json ./
+COPY packages/sandbox-server/package.json ./packages/sandbox-server/
+
+# Install dependencies (ignore prepare scripts like husky)
+RUN npm install --workspace=@prodisco/sandbox-server --ignore-scripts
+
+# Copy source files
+COPY packages/sandbox-server/ ./packages/sandbox-server/
+
+# Build the sandbox-server
+RUN npm run build --workspace=@prodisco/sandbox-server
+
+# Production stage
+FROM node:22-alpine
+
+WORKDIR /app
+
+# Install only production dependencies (ignore prepare scripts)
+COPY package.json ./
+COPY packages/sandbox-server/package.json ./packages/sandbox-server/
+
+RUN npm install --workspace=@prodisco/sandbox-server --omit=dev --ignore-scripts
+
+# Copy built files from builder
+COPY --from=builder /app/packages/sandbox-server/dist ./packages/sandbox-server/dist
+
+# Create cache directory for scripts
+RUN mkdir -p /tmp/prodisco-scripts
+
+# Set environment variables
+ENV NODE_ENV=production
+ENV SANDBOX_USE_TCP=true
+ENV SANDBOX_TCP_HOST=0.0.0.0
+ENV SANDBOX_TCP_PORT=50051
+ENV SCRIPTS_CACHE_DIR=/tmp/prodisco-scripts
+
+# Expose gRPC port
+EXPOSE 50051
+
+# Run the sandbox server
+CMD ["node", "packages/sandbox-server/dist/server/index.js"]

--- a/packages/sandbox-server/k8s/deployment.yaml
+++ b/packages/sandbox-server/k8s/deployment.yaml
@@ -1,0 +1,162 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prodisco
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sandbox-server
+  namespace: prodisco
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sandbox-server
+rules:
+  # Read access to most resources for querying
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+      - services
+      - endpoints
+      - configmaps
+      - secrets
+      - namespaces
+      - nodes
+      - persistentvolumes
+      - persistentvolumeclaims
+      - events
+      - serviceaccounts
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - storageclasses
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources:
+      - poddisruptionbudgets
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sandbox-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sandbox-server
+subjects:
+  - kind: ServiceAccount
+    name: sandbox-server
+    namespace: prodisco
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sandbox-server
+  namespace: prodisco
+  labels:
+    app: sandbox-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sandbox-server
+  template:
+    metadata:
+      labels:
+        app: sandbox-server
+    spec:
+      serviceAccountName: sandbox-server
+      containers:
+        - name: sandbox
+          image: prodisco/sandbox-server:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 50051
+              name: grpc
+              protocol: TCP
+          env:
+            - name: SANDBOX_USE_TCP
+              value: "true"
+            - name: SANDBOX_TCP_HOST
+              value: "0.0.0.0"
+            - name: SANDBOX_TCP_PORT
+              value: "50051"
+            - name: SCRIPTS_CACHE_DIR
+              value: "/tmp/prodisco-scripts"
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            exec:
+              command:
+                - node
+                - -e
+                - |
+                  const grpc = require('@grpc/grpc-js');
+                  const client = new grpc.Client('localhost:50051', grpc.credentials.createInsecure());
+                  client.waitForReady(Date.now() + 1000, (err) => process.exit(err ? 1 : 0));
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command:
+                - node
+                - -e
+                - |
+                  const grpc = require('@grpc/grpc-js');
+                  const client = new grpc.Client('localhost:50051', grpc.credentials.createInsecure());
+                  client.waitForReady(Date.now() + 1000, (err) => process.exit(err ? 1 : 0));
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          volumeMounts:
+            - name: scripts-cache
+              mountPath: /tmp/prodisco-scripts
+      volumes:
+        - name: scripts-cache
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sandbox-server
+  namespace: prodisco
+  labels:
+    app: sandbox-server
+spec:
+  type: ClusterIP
+  ports:
+    - port: 50051
+      targetPort: 50051
+      protocol: TCP
+      name: grpc
+  selector:
+    app: sandbox-server

--- a/scripts/integration/container-tests.ts
+++ b/scripts/integration/container-tests.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env npx tsx
+/**
+ * Integration tests for the containerized sandbox-server.
+ * Run with: npx tsx scripts/integration/container-tests.ts
+ */
+
+import { SandboxClient } from '../../packages/sandbox-server/dist/client/index.js';
+
+interface TestResult {
+  name: string;
+  passed: boolean;
+  error?: string;
+}
+
+interface TestCase {
+  name: string;
+  fn: () => Promise<void>;
+}
+
+async function runTests(): Promise<void> {
+  const port = parseInt(process.env.SANDBOX_PORT || '50052', 10);
+  const host = process.env.SANDBOX_HOST || 'localhost';
+
+  console.log(`Connecting to sandbox server at ${host}:${port}...\n`);
+
+  const client = new SandboxClient({
+    useTcp: true,
+    tcpHost: host,
+    tcpPort: port,
+  });
+
+  // Wait for server to be ready
+  const healthy = await client.waitForHealthy(10000);
+  if (!healthy) {
+    console.error('ERROR: Server not healthy after 10 seconds');
+    process.exit(1);
+  }
+
+  const results: TestResult[] = [];
+  let passed = 0;
+  let failed = 0;
+
+  function test(name: string, fn: () => Promise<void>): TestCase {
+    return { name, fn };
+  }
+
+  const tests: TestCase[] = [
+    test('Health check returns healthy', async () => {
+      const health = await client.healthCheck();
+      if (!health.healthy) throw new Error('Server not healthy');
+      if (health.kubernetesContext !== 'inClusterContext') {
+        throw new Error('Expected inClusterContext, got: ' + health.kubernetesContext);
+      }
+    }),
+
+    test('Execute simple code', async () => {
+      const result = await client.execute({
+        code: 'console.log("test");',
+        timeoutMs: 5000,
+      });
+      if (!result.success) throw new Error('Execution failed: ' + result.error);
+      if (!result.output.includes('test')) throw new Error('Output mismatch');
+    }),
+
+    test('Execute TypeScript code', async () => {
+      const result = await client.execute({
+        code: 'const x: number = 42; console.log(x);',
+        timeoutMs: 5000,
+      });
+      if (!result.success) throw new Error('Execution failed: ' + result.error);
+      if (!result.output.includes('42')) throw new Error('Output mismatch');
+    }),
+
+    test('Kubernetes API access - list namespaces', async () => {
+      const result = await client.execute({
+        code: `
+          const coreV1Api = kc.makeApiClient(k8s.CoreV1Api);
+          const namespaces = await coreV1Api.listNamespace();
+          console.log('Namespace count:', namespaces.items.length);
+          console.log('Has prodisco:', namespaces.items.some(ns => ns.metadata?.name === 'prodisco'));
+        `,
+        timeoutMs: 10000,
+      });
+      if (!result.success) throw new Error('Execution failed: ' + result.error);
+      if (!result.output.includes('Has prodisco: true')) {
+        throw new Error('Expected to find prodisco namespace. Output: ' + result.output);
+      }
+    }),
+
+    test('Kubernetes API access - list pods in prodisco', async () => {
+      const result = await client.execute({
+        code: `
+          const coreV1Api = kc.makeApiClient(k8s.CoreV1Api);
+          const pods = await coreV1Api.listNamespacedPod({ namespace: 'prodisco' });
+          console.log('Pod count:', pods.items.length);
+          const sandboxPod = pods.items.find(p => p.metadata?.name?.includes('sandbox-server'));
+          console.log('Sandbox pod found:', !!sandboxPod);
+          console.log('Sandbox pod status:', sandboxPod?.status?.phase);
+        `,
+        timeoutMs: 10000,
+      });
+      if (!result.success) throw new Error('Execution failed: ' + result.error);
+      if (!result.output.includes('Sandbox pod found: true')) {
+        throw new Error('Expected to find sandbox-server pod. Output: ' + result.output);
+      }
+    }),
+
+    test('Script caching works', async () => {
+      const result = await client.execute({
+        code: '// Cache test script\nconsole.log("cached!");',
+        timeoutMs: 5000,
+      });
+      if (!result.success) throw new Error('Execution failed: ' + result.error);
+      if (!result.cachedAs) throw new Error('Script was not cached');
+    }),
+
+    test('Error handling - syntax error', async () => {
+      const result = await client.execute({
+        code: 'const x = {;',
+        timeoutMs: 5000,
+      });
+      if (result.success) throw new Error('Expected failure for syntax error');
+      if (!result.error) throw new Error('Expected error message');
+    }),
+
+    test('Timeout handling', async () => {
+      // This test verifies that infinite loops are handled.
+      // The execution should either:
+      // 1. Return with success=false (timeout handled gracefully)
+      // 2. Throw a gRPC error (connection dropped due to timeout)
+      // Both are acceptable - what matters is that it doesn't succeed.
+      try {
+        const result = await client.execute({
+          code: 'while(true) {}',
+          timeoutMs: 1000,
+        });
+        if (result.success) throw new Error('Expected timeout failure');
+        // Got a failed result - this is correct behavior
+      } catch (error) {
+        // Connection dropped due to timeout - also acceptable
+        const message = error instanceof Error ? error.message : String(error);
+        if (message.includes('UNAVAILABLE') || message.includes('timeout') || message.includes('deadline')) {
+          // This is expected behavior for a timeout
+          return;
+        }
+        throw error;
+      }
+    }),
+  ];
+
+  console.log(`Running ${tests.length} tests...\n`);
+
+  for (const { name, fn } of tests) {
+    try {
+      await fn();
+      console.log('  \u2713 ' + name);
+      passed++;
+      results.push({ name, passed: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.log('  \u2717 ' + name + ': ' + message);
+      failed++;
+      results.push({ name, passed: false, error: message });
+    }
+  }
+
+  console.log(`\n${passed}/${tests.length} tests passed`);
+
+  client.close();
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+runTests().catch((err) => {
+  console.error('Test runner error:', err);
+  process.exit(1);
+});

--- a/scripts/integration/run-container-integration.sh
+++ b/scripts/integration/run-container-integration.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Integration test for the containerized sandbox-server.
+# Creates a kind cluster, builds and loads the Docker image, deploys, and tests.
+#
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CLUSTER_NAME="${CLUSTER_NAME:-sandbox-int}"
+KIND_BIN="${KIND_BIN:-kind}"
+KUBECTL_BIN="${KUBECTL_BIN:-kubectl}"
+ARTIFACT_DIR="${ROOT_DIR}/artifacts/container-integration"
+KUBECONFIG_PATH="${ARTIFACT_DIR}/kubeconfig"
+IMAGE_NAME="prodisco/sandbox-server:test"
+NAMESPACE="prodisco"
+LOCAL_PORT="${LOCAL_PORT:-50052}"  # Use different port to avoid conflicts
+
+log() {
+  echo "[container-integration] $*"
+}
+
+ensure_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required command '$1' not found in PATH" >&2
+    exit 1
+  fi
+}
+
+cleanup() {
+  set +e
+  log "Cleaning up KIND cluster ${CLUSTER_NAME}"
+  "$KIND_BIN" delete cluster --name "$CLUSTER_NAME" >/dev/null 2>&1
+}
+
+# Check required commands
+ensure_command "$KIND_BIN"
+ensure_command "$KUBECTL_BIN"
+ensure_command docker
+ensure_command npm
+ensure_command node
+
+mkdir -p "$ARTIFACT_DIR"
+trap cleanup EXIT
+
+# Step 1: Create KIND cluster
+log "Creating KIND cluster ${CLUSTER_NAME}"
+"$KIND_BIN" delete cluster --name "$CLUSTER_NAME" >/dev/null 2>&1 || true
+"$KIND_BIN" create cluster --name "$CLUSTER_NAME" --wait 180s
+
+log "Writing kubeconfig to ${KUBECONFIG_PATH}"
+"$KIND_BIN" get kubeconfig --name "$CLUSTER_NAME" >"$KUBECONFIG_PATH"
+export KUBECONFIG="$KUBECONFIG_PATH"
+
+# Step 2: Build the sandbox-server (skip if already built)
+cd "$ROOT_DIR"
+if [ -d "packages/sandbox-server/dist" ] && [ -f "packages/sandbox-server/dist/server/index.js" ]; then
+  log "sandbox-server already built, skipping build step"
+else
+  log "Building sandbox-server package"
+  npm run build -w @prodisco/sandbox-server
+fi
+
+# Step 3: Build Docker image
+log "Building Docker image ${IMAGE_NAME}"
+docker build -f packages/sandbox-server/Dockerfile -t "$IMAGE_NAME" .
+
+# Step 4: Load image into kind
+log "Loading image into kind cluster"
+"$KIND_BIN" load docker-image "$IMAGE_NAME" --name "$CLUSTER_NAME"
+
+# Step 5: Deploy sandbox-server (update image in manifest)
+log "Deploying sandbox-server to cluster"
+
+# Create a temporary manifest with the test image
+TEMP_MANIFEST="${ARTIFACT_DIR}/deployment.yaml"
+sed "s|prodisco/sandbox-server:latest|${IMAGE_NAME}|g" \
+  "$ROOT_DIR/packages/sandbox-server/k8s/deployment.yaml" > "$TEMP_MANIFEST"
+
+"$KUBECTL_BIN" apply -f "$TEMP_MANIFEST"
+
+# Step 6: Wait for deployment to be ready
+log "Waiting for sandbox-server deployment to be ready"
+"$KUBECTL_BIN" -n "$NAMESPACE" wait --for=condition=available deployment/sandbox-server --timeout=120s
+
+# Verify pod is running
+"$KUBECTL_BIN" -n "$NAMESPACE" get pods -l app=sandbox-server
+
+# Check logs
+log "Sandbox server logs:"
+"$KUBECTL_BIN" -n "$NAMESPACE" logs deployment/sandbox-server
+
+# Step 7: Port-forward and run tests
+log "Setting up port-forward on local port ${LOCAL_PORT}"
+"$KUBECTL_BIN" -n "$NAMESPACE" port-forward service/sandbox-server "${LOCAL_PORT}:50051" &
+PORT_FORWARD_PID=$!
+
+# Wait for port-forward to be ready
+sleep 3
+
+# Verify port-forward is running
+if ! kill -0 $PORT_FORWARD_PID 2>/dev/null; then
+  log "ERROR: Port-forward failed to start"
+  exit 1
+fi
+
+log "Running integration tests"
+SANDBOX_PORT="$LOCAL_PORT" npx tsx "$ROOT_DIR/scripts/integration/container-tests.ts"
+
+# Cleanup port-forward
+kill $PORT_FORWARD_PID 2>/dev/null || true
+
+log "Container integration tests completed successfully!"


### PR DESCRIPTION
## Summary

- Add container isolation for sandbox-server with Dockerfile and Kubernetes manifests
- Add comprehensive CI integration tests that deploy to a kind cluster and verify functionality

## Key Changes

### Container Isolation
- Multi-stage Dockerfile for minimal production image
- Kubernetes manifests with proper RBAC for cluster access:
  - Deployment, Service, ServiceAccount
  - ClusterRole and ClusterRoleBinding for K8s API access

### CI Integration Tests
- New `container-integration` job in CI workflow
- Creates a kind cluster, builds/deploys the sandbox server
- Runs integration tests verifying:
  - Health check with in-cluster context
  - Code execution (simple, TypeScript)
  - Kubernetes API access from sandbox
  - Script caching
  - Error and timeout handling

## Test plan

- [x] All 600 unit tests pass locally
- [x] Container integration tests pass locally (8/8 tests)
- [ ] CI `build-and-test` job passes
- [ ] CI `container-integration` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)