### PR TITLE
docs: Update architecture and integration testing docs for container …

### DIFF
--- a/docs/grpc-sandbox-architecture.md
+++ b/docs/grpc-sandbox-architecture.md
@@ -490,6 +490,51 @@ const client3 = new SandboxClient();
 | Sandbox on remote host | TCP |
 | Production with network isolation | TCP with TLS (see Future Enhancements) |
 
+## Container Isolation
+
+The sandbox server can run in a Kubernetes cluster for stronger isolation. This is the recommended deployment model for production.
+
+### Files
+
+- **Dockerfile**: [`packages/sandbox-server/Dockerfile`](../packages/sandbox-server/Dockerfile) - Multi-stage build that produces a minimal production image
+- **Kubernetes manifests**: [`packages/sandbox-server/k8s/deployment.yaml`](../packages/sandbox-server/k8s/deployment.yaml) - Namespace, ServiceAccount, RBAC, Deployment, and Service
+
+### Building and Deploying
+
+```bash
+# Build the Docker image
+docker build -f packages/sandbox-server/Dockerfile -t prodisco/sandbox-server:latest .
+
+# For kind clusters, load the image
+kind load docker-image prodisco/sandbox-server:latest
+
+# Deploy to Kubernetes
+kubectl apply -f packages/sandbox-server/k8s/deployment.yaml
+
+# Connect from outside the cluster
+kubectl -n prodisco port-forward service/sandbox-server 50051:50051
+```
+
+### Connecting to Containerized Sandbox
+
+```typescript
+import { SandboxClient } from '@prodisco/sandbox-server';
+
+// Via port-forward
+const client = new SandboxClient({
+  useTcp: true,
+  tcpHost: 'localhost',
+  tcpPort: 50051,
+});
+
+// Or via in-cluster DNS
+const client = new SandboxClient({
+  useTcp: true,
+  tcpHost: 'sandbox-server.prodisco.svc.cluster.local',
+  tcpPort: 50051,
+});
+```
+
 ## Future Enhancements
 
 ### TLS/mTLS
@@ -500,21 +545,6 @@ const credentials = grpc.credentials.createSsl(
   fs.readFileSync('client-key.pem'),
   fs.readFileSync('client-cert.pem')
 );
-```
-
-### Container Isolation
-Run the sandbox server in a container for stronger isolation:
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: sandbox-server
-spec:
-  containers:
-  - name: sandbox
-    image: prodisco/sandbox-server:latest
-    ports:
-    - containerPort: 50051
 ```
 
 ### Streaming Execution

--- a/docs/integration-testing.md
+++ b/docs/integration-testing.md
@@ -72,3 +72,54 @@ the cluster.
 CI currently skips this workflow; it is intended for manual validation on a
 developer workstation.
 
+## Container Integration Tests
+
+The project also includes automated container integration tests that run in CI. These tests verify the sandbox-server works correctly when deployed as a container in a Kubernetes cluster.
+
+### Running Container Integration Tests
+
+```bash
+./scripts/integration/run-container-integration.sh
+```
+
+Or with a custom local port (to avoid conflicts):
+
+```bash
+LOCAL_PORT=50053 ./scripts/integration/run-container-integration.sh
+```
+
+### Files
+
+- **Test runner**: [`scripts/integration/run-container-integration.sh`](../scripts/integration/run-container-integration.sh) - Creates KIND cluster, builds/loads Docker image, deploys, and runs tests
+- **Test suite**: [`scripts/integration/container-tests.ts`](../scripts/integration/container-tests.ts) - TypeScript tests for health check, code execution, K8s API access, caching, and error handling
+- **CI workflow**: [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) - The `container-integration` job
+
+### What the Test Does
+
+1. Creates a KIND cluster (`sandbox-int`)
+2. Builds the sandbox-server Docker image
+3. Loads the image into KIND and deploys using K8s manifests
+4. Sets up port-forwarding to the sandbox-server service
+5. Runs the test suite which verifies:
+   - Health check returns healthy with `inClusterContext`
+   - Simple code and TypeScript execution
+   - Kubernetes API access (list namespaces, list pods)
+   - Script caching
+   - Error and timeout handling
+6. Cleans up the KIND cluster
+
+### Environment Variables
+
+| Variable      | Default       | Description                                      |
+|---------------|---------------|--------------------------------------------------|
+| `CLUSTER_NAME`| `sandbox-int` | KIND cluster name for container tests            |
+| `LOCAL_PORT`  | `50052`       | Local port for port-forwarding (avoids conflicts)|
+| `KIND_BIN`    | `kind`        | Custom path to the `kind` binary                 |
+| `KUBECTL_BIN` | `kubectl`     | Custom path to `kubectl`                         |
+
+### Artifacts
+
+Container integration test artifacts are stored in `artifacts/container-integration/`:
+- `kubeconfig` - Kubeconfig for the test cluster
+- `deployment.yaml` - The actual manifest applied to the cluster
+


### PR DESCRIPTION
…isolation

- Move Container Isolation from Future Enhancements to implemented section
- Add file references (Dockerfile, K8s manifests) instead of full code blocks
- Add Container Integration Tests section to integration-testing.md
- Document test runner, test suite, and CI workflow with file links

🤖 Generated with [Claude Code](https://claude.com/claude-code)