### PR TITLE
fix: Add @prodisco/sandbox-server as dependency and fix flaky tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.12.5",
+    "@prodisco/sandbox-server": "^0.1.0",
     "@kubernetes/client-node": "^1.4.0",
     "@modelcontextprotocol/sdk": "^1.24.3",
     "@orama/orama": "^3.1.5",

--- a/packages/sandbox-server/src/__tests__/sandbox-service.test.ts
+++ b/packages/sandbox-server/src/__tests__/sandbox-service.test.ts
@@ -5,11 +5,16 @@ import type { ExecuteRequest, ExecuteResponse, HealthCheckRequest, HealthCheckRe
 import { existsSync, rmSync } from 'node:fs';
 
 describe('SandboxService', () => {
-  const testCacheDir = '/tmp/prodisco-service-test-' + Date.now();
+  // Use unique cache directory per test to avoid conflicts when .ts and .js tests run in parallel
+  let testCacheDir: string;
+
+  beforeEach(() => {
+    testCacheDir = `/tmp/prodisco-service-test-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  });
 
   afterEach(() => {
     if (existsSync(testCacheDir)) {
-      rmSync(testCacheDir, { recursive: true });
+      rmSync(testCacheDir, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
## Summary

- Add `@prodisco/sandbox-server` as an explicit dependency in package.json
- Fix flaky sandbox-service tests caused by parallel test execution

## Changes

### Dependency Fix
The published `@prodisco/k8s-mcp` package was failing because it imports from `@prodisco/sandbox-server` but that package wasn't listed as a dependency. This caused the MCP server to fail when installed via `npx -y @prodisco/k8s-mcp`.

### Test Fix
The `sandbox-service.test.ts` was using `Date.now()` at module load time for the cache directory path. When vitest runs both `.ts` source tests and `.js` dist tests in parallel, they could get the same timestamp, causing test isolation failures.

Fixed by:
- Moving `testCacheDir` to a `let` variable initialized in `beforeEach`
- Adding `Math.random()` for guaranteed uniqueness per test
- Adding `force: true` to `rmSync` for robust cleanup

## Test plan
- [x] All 818 tests pass consistently
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)