### PR TITLE
chore: Bump version to 0.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prodisco/k8s-mcp",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "ProDisco: Kubernetes MCP server with progressive disclosure",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary
- Bumps @prodisco/k8s-mcp version to 0.1.9

## Changes in this release
- fix: Use require.resolve to find sandbox-server package (works both in development and npm install)
- test: Add npm pack integration test
- ci: Add npm pack integration test to CI workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)